### PR TITLE
feat(lexer): implementa regra para ignorar preprocessor directives (#38)

### DIFF
--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -103,13 +103,22 @@ impl Scanner {
                 self.src.advance();
             }
 
-            // Comentarios
+            // Comentarios de linha
             if self.src.peek() == Some('/') && self.src.peek_ahead() == Some('/') {
                 while !matches!(self.src.peek(), Some('\n') | None) {
                     self.src.advance();
                 }
                 continue;
             }
+
+            // Diretivas de pré-processador (#)
+            if self.src.peek() == Some('#') {
+                while !matches!(self.src.peek(), Some('\n') | None) {
+                    self.src.advance();
+                }
+                continue;
+            }
+
             break;
         }
     }

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -26,7 +26,7 @@ impl Scanner {
     // Roda o scanner ate o fim do arquivo e retorna os tokens produzidos
     pub fn scan(&mut self) -> &[Token] {
         while !self.src.is_at_end() {
-            self.skip_whitespaces_and_comments();
+            self.skip_whitespaces_comments_and_directives();
             if self.src.is_at_end() {
                 break;
             }
@@ -94,7 +94,7 @@ impl Scanner {
 
     // Ignorar espaços em branco e Comentarios
     // Nao geram tokens
-    fn skip_whitespaces_and_comments(&mut self) {
+    fn skip_whitespaces_comments_and_directives(&mut self) {
         loop {
             while matches!(
                 self.src.peek(),

--- a/src/tests/lexical_test.rs
+++ b/src/tests/lexical_test.rs
@@ -99,13 +99,13 @@ mod tests {
     #[test]
     fn multiple_unknowns_keep_scanning() {
         // O scanner não para no primeiro erro
-        let src = SourceFile::from_string("@ # $");
+        let src = SourceFile::from_string("@ ? $");
         let mut scanner = Scanner::new(src);
         scanner.scan();
         assert_eq!(scanner.diagnostics.len(), 3);
     }
 
-    // --- Comentários são ignorados ---
+    // --- Comentários e Diretivas são ignorados ---
 
     #[test]
     fn line_comments_are_skipped() {
@@ -113,6 +113,15 @@ mod tests {
         assert_eq!(
             kinds,
             vec![TokenKind::IntLiteral(42), TokenKind::IntLiteral(99),]
+        );
+    }
+
+    #[test]
+    fn preprocessor_directives_are_skipped() {
+        let kinds = scan("#include <stdio.h>\n#define MAX 10\n42");
+        assert_eq!(
+            kinds,
+            vec![TokenKind::IntLiteral(42)]
         );
     }
 }


### PR DESCRIPTION
Resolves #38

## Descrição
Implementa no scanner uma regra para ignorar linhas que começam com diretivas de pré-processador do C (ex: `#include`, `#define`, etc). Agora, ao encontrar um `#` no início da linha, o lexer consome e ignora todo o conteúdo até a próxima quebra de linha, sem gerar tokens ou diagnósticos de erro.

## O que foi alterado
- `src/lexer/scanner.rs`: Adicionada lógica para pular linhas iniciadas por `#`.
- `src/tests/lexical_test.rs`: Adicionado teste `preprocessor_directives_are_skipped` para garantir que diretivas são ignoradas corretamente. Ajustado teste de múltiplos unknowns para não conflitar com a nova regra.

## Como testar
Execute:
```bash
cargo test