### PR TITLE
feat(lexer): implementa operadores, comentários de bloco e detecção de delimitadores não fechados

### DIFF
--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -25,20 +25,39 @@ impl ToReport for CompilerError {
 }
 
 #[derive(Debug)]
+pub enum LexicalErrorKind {
+    /// Caractere que o lexer não reconhece (ex: `@`, `$`)
+    InvalidChar(char),
+    /// `/*` aberto mas nunca fechado com `*/`
+    UnclosedBlockComment,
+    /// `(`, `[` ou `{` aberto mas nunca fechado
+    UnclosedDelimiter(char),
+}
+
+#[derive(Debug)]
 pub struct LexicalError {
     pub span: Span,
-    pub invalid_char: char,
+    pub kind: LexicalErrorKind,
 }
 
 impl ToReport for LexicalError {
     fn to_report(&self) -> Report {
-        Report::new("invalid character")
-            .with_span(self.span.clone())
-            .with_label(
-                self.span.clone(),
-                format!("'{}' nao e valido", self.invalid_char),
-            )
-            .with_help("Remova ou substitua o caractere.")
+        match &self.kind {
+            LexicalErrorKind::InvalidChar(c) => Report::new("invalid character")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), format!("'{}' nao e valido", c))
+                .with_help("Remova ou substitua o caractere."),
+
+            LexicalErrorKind::UnclosedBlockComment => Report::new("unclosed block comment")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), "comentario de bloco nao fechado".to_string())
+                .with_help("Adicione '*/' para fechar o comentario."),
+
+            LexicalErrorKind::UnclosedDelimiter(c) => Report::new("unclosed delimiter")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), format!("'{}' nao foi fechado", c))
+                .with_help("Adicione o delimitador de fechamento correspondente."),
+        }
     }
 }
 

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -32,6 +32,8 @@ pub enum LexicalErrorKind {
     UnclosedBlockComment,
     /// `(`, `[` ou `{` aberto mas nunca fechado
     UnclosedDelimiter(char),
+    /// String ou char literal não fechada (ex: `"hello` sem `"`)
+    UnterminatedLiteral(String),
 }
 
 #[derive(Debug)]
@@ -57,6 +59,11 @@ impl ToReport for LexicalError {
                 .with_span(self.span.clone())
                 .with_label(self.span.clone(), format!("'{}' nao foi fechado", c))
                 .with_help("Adicione o delimitador de fechamento correspondente."),
+
+            LexicalErrorKind::UnterminatedLiteral(lit) => Report::new("unterminated literal")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), format!("literal '{}' nao foi terminada", lit))
+                .with_help("Feche a string ou char corretamente."),
         }
     }
 }

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -32,6 +32,8 @@ pub enum LexicalErrorKind {
     UnclosedBlockComment,
     /// `(`, `[` ou `{` aberto mas nunca fechado
     UnclosedDelimiter(char),
+    /// `)`, `]` ou `}` encontrado sem par de abertura correspondente
+    UnexpectedClosingDelimiter(char),
     /// String ou char literal não fechada (ex: `"hello` sem `"`)
     UnterminatedLiteral(String),
 }
@@ -59,6 +61,11 @@ impl ToReport for LexicalError {
                 .with_span(self.span.clone())
                 .with_label(self.span.clone(), format!("'{}' nao foi fechado", c))
                 .with_help("Adicione o delimitador de fechamento correspondente."),
+
+            LexicalErrorKind::UnexpectedClosingDelimiter(c) => Report::new("unexpected closing delimiter")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), format!("'{}' nao tem par de abertura", c))
+                .with_help("Remova o delimitador ou adicione o par de abertura correspondente."),
 
             LexicalErrorKind::UnterminatedLiteral(lit) => Report::new("unterminated literal")
                 .with_span(self.span.clone())

--- a/src/lexer/rules/mod.rs
+++ b/src/lexer/rules/mod.rs
@@ -1,2 +1,3 @@
 pub mod identifiers;
 pub mod literals;
+pub mod operators;

--- a/src/lexer/rules/operators.rs
+++ b/src/lexer/rules/operators.rs
@@ -1,0 +1,108 @@
+use crate::lexer::scanner::Scanner;
+use crate::lexer::tokens::TokenKind;
+
+pub trait OperatorRules {
+    fn lex_operator(&mut self, c: char, line: usize, col: usize);
+}
+
+impl OperatorRules for Scanner {
+    fn lex_operator(&mut self, c: char, line: usize, col: usize) {
+        match c {
+            // -------------------------------------------------------
+            // + : ++ | += | +
+            '+' => match self.src.peek() {
+                Some('+') => { self.src.advance(); self.emit_at(TokenKind::PlusPlus,   "++", line, col); }
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::PlusEqual,  "+=", line, col); }
+                _         =>                       self.emit_at(TokenKind::Plus,        "+",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // - : -- | -= | -> | -
+            '-' => match self.src.peek() {
+                Some('-') => { self.src.advance(); self.emit_at(TokenKind::MinusMinus, "--", line, col); }
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::MinusEqual, "-=", line, col); }
+                Some('>') => { self.src.advance(); self.emit_at(TokenKind::Arrow,      "->", line, col); }
+                _         =>                       self.emit_at(TokenKind::Minus,      "-",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // * : *= | *
+            '*' => match self.src.peek() {
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::StarEqual,  "*=", line, col); }
+                _         =>                       self.emit_at(TokenKind::Star,        "*",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // / : /= | /
+            // Nota: '//' e '/*' já são consumidos em skip_whitespaces_and_comments
+            // então aqui só chegam '/' isolado ou '/='
+            '/' => match self.src.peek() {
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::SlashEqual, "/=", line, col); }
+                _         =>                       self.emit_at(TokenKind::Slash,       "/",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // = : == | =
+            '=' => match self.src.peek() {
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::EqualEqual, "==", line, col); }
+                _         =>                       self.emit_at(TokenKind::Equal,       "=",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // ! : != | !
+            '!' => match self.src.peek() {
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::BangEqual,  "!=", line, col); }
+                _         =>                       self.emit_at(TokenKind::Bang,        "!",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // < : <= | <<= | << | <
+            '<' => match self.src.peek() {
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::LessEqual,  "<=", line, col); }
+                Some('<') => {
+                    self.src.advance();
+                    if self.src.peek() == Some('=') {
+                        self.src.advance();
+                        self.emit_at(TokenKind::LessLessEqual, "<<=", line, col);
+                    } else {
+                        self.emit_at(TokenKind::LessLess, "<<", line, col);
+                    }
+                }
+                _ => self.emit_at(TokenKind::Less, "<", line, col),
+            },
+
+            // -------------------------------------------------------
+            // > : >= | >>= | >> | >
+            '>' => match self.src.peek() {
+                Some('=') => { self.src.advance(); self.emit_at(TokenKind::GreaterEqual, ">=", line, col); }
+                Some('>') => {
+                    self.src.advance();
+                    if self.src.peek() == Some('=') {
+                        self.src.advance();
+                        self.emit_at(TokenKind::GreaterGreaterEqual, ">>=", line, col);
+                    } else {
+                        self.emit_at(TokenKind::GreaterGreater, ">>", line, col);
+                    }
+                }
+                _ => self.emit_at(TokenKind::Greater, ">", line, col),
+            },
+
+            // -------------------------------------------------------
+            // & : && | &
+            '&' => match self.src.peek() {
+                Some('&') => { self.src.advance(); self.emit_at(TokenKind::AndAnd,    "&&", line, col); }
+                _         =>                       self.emit_at(TokenKind::Ampersand,  "&",  line, col),
+            },
+
+            // -------------------------------------------------------
+            // | : || | |
+            '|' => match self.src.peek() {
+                Some('|') => { self.src.advance(); self.emit_at(TokenKind::OrOr,  "||", line, col); }
+                _         =>                       self.emit_at(TokenKind::Pipe,   "|",  line, col),
+            },
+
+            // Qualquer outro char cai aqui como desconhecido
+            other => self.emit_unknown(other, line, col),
+        }
+    }
+}

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -75,10 +75,31 @@ impl Scanner {
             '[' => { self.delimiter_stack.push(('[', line, col)); self.emit_at(TokenKind::LeftBracket,  "[", line, col); }
             '{' => { self.delimiter_stack.push(('{', line, col)); self.emit_at(TokenKind::LeftBrace,    "{", line, col); }
 
-            // Delimitadores de fechamento — desempilha o par correspondente
-            ')' => { if matches!(self.delimiter_stack.last(), Some(('(', _, _))) { self.delimiter_stack.pop(); } self.emit_at(TokenKind::RightParen,    ")", line, col); }
-            ']' => { if matches!(self.delimiter_stack.last(), Some(('[', _, _))) { self.delimiter_stack.pop(); } self.emit_at(TokenKind::RightBracket,  "]", line, col); }
-            '}' => { if matches!(self.delimiter_stack.last(), Some(('{', _, _))) { self.delimiter_stack.pop(); } self.emit_at(TokenKind::RightBrace,    "}", line, col); }
+            // Delimitadores de fechamento — desempilha o par ou reporta mismatch/inesperado
+            ')' => {
+                if matches!(self.delimiter_stack.last(), Some(('(', _, _))) {
+                    self.delimiter_stack.pop();
+                } else {
+                    self.emit_unexpected_delimiter(')', line, col);
+                }
+                self.emit_at(TokenKind::RightParen, ")", line, col);
+            }
+            ']' => {
+                if matches!(self.delimiter_stack.last(), Some(('[', _, _))) {
+                    self.delimiter_stack.pop();
+                } else {
+                    self.emit_unexpected_delimiter(']', line, col);
+                }
+                self.emit_at(TokenKind::RightBracket, "]", line, col);
+            }
+            '}' => {
+                if matches!(self.delimiter_stack.last(), Some(('{', _, _))) {
+                    self.delimiter_stack.pop();
+                } else {
+                    self.emit_unexpected_delimiter('}', line, col);
+                }
+                self.emit_at(TokenKind::RightBrace, "}", line, col);
+            }
 
             // Pontuação simples sem lookahead
             '%' => self.emit_at(TokenKind::Percent,   "%", line, col),
@@ -136,6 +157,7 @@ impl Scanner {
                 self.src.advance(); // '/'
                 self.src.advance(); // '*'
 
+                let mut closed = false;
                 loop {
                     match self.src.advance() {
                         None => {
@@ -147,16 +169,17 @@ impl Scanner {
                                 },
                                 kind: LexicalErrorKind::UnclosedBlockComment,
                             }));
-                            return;
+                            break;
                         }
                         Some('*') if self.src.peek() == Some('/') => {
                             self.src.advance(); // '/'
+                            closed = true;
                             break;
                         }
                         _ => {}
                     }
                 }
-                continue;
+                if closed { continue; } else { break; }
             }
 
             // Diretivas de pré-processador: #include, #define, etc.
@@ -182,6 +205,13 @@ impl Scanner {
             kind: LexicalErrorKind::InvalidChar(c),
         }));
         self.emit_at(TokenKind::Unknown(c), &c.to_string(), line, col);
+    }
+
+    fn emit_unexpected_delimiter(&mut self, c: char, line: usize, col: usize) {
+        self.diagnostics.push(CompilerError::Lexical(LexicalError {
+            span: Span { line, column_start: col, column_end: col + 1 },
+            kind: LexicalErrorKind::UnexpectedClosingDelimiter(c),
+        }));
     }
 
     // Emite um diagnóstico de literal não terminada (string ou char sem fechamento)

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -221,4 +221,17 @@ impl Scanner {
         }));
         self.emit_at(TokenKind::Unknown(c), &c.to_string(), line, col);
     }
+
+    // Emite um diagnóstico de literal não terminada (string ou char sem fechamento)
+    // Adicionado pela branch developer; atualizado para usar LexicalErrorKind
+    pub fn emit_unterminated_literal(&mut self, lit: &str, line: usize, col_start: usize, col_end: usize) {
+        self.diagnostics.push(CompilerError::Lexical(LexicalError {
+            span: Span {
+                line,
+                column_start: col_start,
+                column_end: col_end,
+            },
+            kind: LexicalErrorKind::UnterminatedLiteral(lit.to_string()),
+        }));
+    }
 }

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -1,16 +1,22 @@
 use crate::common::errors::{
     error_data::Span,
-    types::{CompilerError, LexicalError},
+    types::{CompilerError, LexicalError, LexicalErrorKind},
 };
 use crate::common::input::source::SourceFile;
 use crate::common::utils::char_utils::is_ident_start;
-use crate::lexer::rules::{identifiers::IdentifierRules, literals::LiteralsRules};
+use crate::lexer::rules::{
+    identifiers::IdentifierRules,
+    literals::LiteralsRules,
+    operators::OperatorRules,
+};
 use crate::lexer::tokens::{token::Token, token_kind::TokenKind};
 
 pub struct Scanner {
     pub src: SourceFile,
     pub tokens: Vec<Token>,
     pub diagnostics: Vec<CompilerError>,
+    /// Pilha de delimitadores abertos ainda não fechados: (char, linha, coluna)
+    delimiter_stack: Vec<(char, usize, usize)>,
 }
 
 impl Scanner {
@@ -20,6 +26,7 @@ impl Scanner {
             src,
             tokens: Vec::new(),
             diagnostics: Vec::new(),
+            delimiter_stack: Vec::new(),
         }
     }
 
@@ -31,6 +38,15 @@ impl Scanner {
                 break;
             }
             self.next_token();
+        }
+
+        // Delimitadores abertos sem fechamento → um diagnóstico por abertura
+        let unclosed: Vec<(char, usize, usize)> = self.delimiter_stack.drain(..).collect();
+        for (c, line, col) in unclosed {
+            self.diagnostics.push(CompilerError::Lexical(LexicalError {
+                span: Span { line, column_start: col, column_end: col + 1 },
+                kind: LexicalErrorKind::UnclosedDelimiter(c),
+            }));
         }
 
         // Sempre termina com EOF para o parser saber que acabou
@@ -57,27 +73,60 @@ impl Scanner {
             '"' => self.lex_string(line, col),
             '\'' => self.lex_char(line, col),
 
-            // Identificadores e keyworkds
+            // Identificadores e keywords
             c if is_ident_start(c) => self.lex_identifier(c, line, col),
 
-            // Operadores e delimitadores de um char só (sem lookahead)
-            '%' => self.emit_at(TokenKind::Percent, "%", line, col),
-            '^' => self.emit_at(TokenKind::Caret, "^", line, col),
-            '~' => self.emit_at(TokenKind::Tilde, "~", line, col),
-            '.' => self.emit_at(TokenKind::Dot, ".", line, col),
-            '(' => self.emit_at(TokenKind::LeftParen, "(", line, col),
-            ')' => self.emit_at(TokenKind::RightParen, ")", line, col),
-            '{' => self.emit_at(TokenKind::LeftBrace, "{", line, col),
-            '}' => self.emit_at(TokenKind::RightBrace, "}", line, col),
-            '[' => self.emit_at(TokenKind::LeftBracket, "[", line, col),
-            ']' => self.emit_at(TokenKind::RightBracket, "]", line, col),
-            ';' => self.emit_at(TokenKind::Semicolon, ";", line, col),
-            ',' => self.emit_at(TokenKind::Comma, ",", line, col),
-            ':' => self.emit_at(TokenKind::Colon, ":", line, col),
+            // ----------------------------------------------------------
+            // Delimitadores de abertura — empilha para rastrear fechamento
+            '(' => {
+                self.delimiter_stack.push(('(', line, col));
+                self.emit_at(TokenKind::LeftParen, "(", line, col);
+            }
+            '[' => {
+                self.delimiter_stack.push(('[', line, col));
+                self.emit_at(TokenKind::LeftBracket, "[", line, col);
+            }
+            '{' => {
+                self.delimiter_stack.push(('{', line, col));
+                self.emit_at(TokenKind::LeftBrace, "{", line, col);
+            }
 
-            // Operadores que precisam de lookahead (+, -, *, /, etc.)
-            // ficam aqui por enquanto como Unknown até operators.rs existir
-            // MODIFICAR ESSA PARTE QUANDO IMPLEMENTAR AS OUTRAS REGRAS
+            // Delimitadores de fechamento — desempilha o par correspondente
+            ')' => {
+                if matches!(self.delimiter_stack.last(), Some(('(', _, _))) {
+                    self.delimiter_stack.pop();
+                }
+                self.emit_at(TokenKind::RightParen, ")", line, col);
+            }
+            ']' => {
+                if matches!(self.delimiter_stack.last(), Some(('[', _, _))) {
+                    self.delimiter_stack.pop();
+                }
+                self.emit_at(TokenKind::RightBracket, "]", line, col);
+            }
+            '}' => {
+                if matches!(self.delimiter_stack.last(), Some(('{', _, _))) {
+                    self.delimiter_stack.pop();
+                }
+                self.emit_at(TokenKind::RightBrace, "}", line, col);
+            }
+
+            // ----------------------------------------------------------
+            // Pontuação simples sem lookahead
+            '%' => self.emit_at(TokenKind::Percent,   "%", line, col),
+            '^' => self.emit_at(TokenKind::Caret,     "^", line, col),
+            '~' => self.emit_at(TokenKind::Tilde,     "~", line, col),
+            '.' => self.emit_at(TokenKind::Dot,       ".", line, col),
+            ';' => self.emit_at(TokenKind::Semicolon, ";", line, col),
+            ',' => self.emit_at(TokenKind::Comma,     ",", line, col),
+            ':' => self.emit_at(TokenKind::Colon,     ":", line, col),
+
+            // ----------------------------------------------------------
+            // Operadores (simples e compostos) — delega para operators.rs
+            '+' | '-' | '*' | '/' | '=' | '!' | '<' | '>' | '&' | '|'
+                => self.lex_operator(c, line, col),
+
+            // Qualquer outro char é inválido
             c => self.emit_unknown(c, line, col),
         }
     }
@@ -95,10 +144,11 @@ impl Scanner {
         });
     }
 
-    // Ignorar espaços em branco e Comentarios
+    // Ignora espaços em branco, comentários de linha (//) e de bloco (/* */)
     // Nao geram tokens
     fn skip_whitespaces_and_comments(&mut self) {
         loop {
+            // Pula whitespace
             while matches!(
                 self.src.peek(),
                 Some(' ') | Some('\t') | Some('\r') | Some('\n')
@@ -106,13 +156,55 @@ impl Scanner {
                 self.src.advance();
             }
 
-            // Comentarios
+            // Comentário de linha: //
             if self.src.peek() == Some('/') && self.src.peek_ahead() == Some('/') {
                 while !matches!(self.src.peek(), Some('\n') | None) {
                     self.src.advance();
                 }
                 continue;
             }
+
+            // Comentário de bloco: /* ... */
+            if self.src.peek() == Some('/') && self.src.peek_ahead() == Some('*') {
+                let comment_line = self.src.line();
+                let comment_col  = self.src.col();
+                self.src.advance(); // '/'
+                self.src.advance(); // '*'
+
+                loop {
+                    match self.src.advance() {
+                        // Fim de arquivo sem fechar → diagnóstico
+                        None => {
+                            self.diagnostics.push(CompilerError::Lexical(LexicalError {
+                                span: Span {
+                                    line: comment_line,
+                                    column_start: comment_col,
+                                    column_end: comment_col + 2,
+                                },
+                                kind: LexicalErrorKind::UnclosedBlockComment,
+                            }));
+                            return; // encerra o skip (e o scan logo a seguir)
+                        }
+                        // '*' seguido de '/' → fecha o bloco
+                        Some('*') if self.src.peek() == Some('/') => {
+                            self.src.advance(); // '/'
+                            break;
+                        }
+                        _ => {} // continua consumindo
+                    }
+                }
+                continue;
+            }
+
+            // Diretivas de pré-processador: #include, #define, etc.
+            // O lexer as ignora — consumidas até o fim da linha
+            if self.src.peek() == Some('#') {
+                while !matches!(self.src.peek(), Some('\n') | None) {
+                    self.src.advance();
+                }
+                continue;
+            }
+
             break;
         }
     }
@@ -125,7 +217,7 @@ impl Scanner {
                 column_start: col,
                 column_end: col + 1,
             },
-            invalid_char: c,
+            kind: LexicalErrorKind::InvalidChar(c),
         }));
         self.emit_at(TokenKind::Unknown(c), &c.to_string(), line, col);
     }

--- a/src/lexer/tokens/token_kind.rs
+++ b/src/lexer/tokens/token_kind.rs
@@ -73,6 +73,12 @@ pub enum TokenKind {
     Ampersand, // &
     Pipe,      // |
 
+    // Operadores de shift
+    LessLess,              // <<
+    GreaterGreater,        // >>
+    LessLessEqual,         // <<=
+    GreaterGreaterEqual,   // >>= 
+
     // Delimitadores
     LeftParen,    // (
     RightParen,   // )

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
     scanner.scan();
 
     for token in &scanner.tokens {
-        let lexeme = &scanner.src.source[token.span.start..token.span.end];
+        let lexeme = &scanner.src.source.as_str()[token.span.start..token.span.end];
         println!("{:?} {:?}", token.kind, lexeme);
     }
 

--- a/src/tests/lexical_test.rs
+++ b/src/tests/lexical_test.rs
@@ -124,4 +124,51 @@ mod tests {
             vec![TokenKind::IntLiteral(42)]
         );
     }
+
+    // --- Operadores compostos ---
+
+    #[test]
+    fn lex_compound_operators() {
+        assert_eq!(scan("=="),  vec![TokenKind::EqualEqual]);
+        assert_eq!(scan("!="),  vec![TokenKind::BangEqual]);
+        assert_eq!(scan("<="),  vec![TokenKind::LessEqual]);
+        assert_eq!(scan(">="),  vec![TokenKind::GreaterEqual]);
+        assert_eq!(scan("&&"),  vec![TokenKind::AndAnd]);
+        assert_eq!(scan("||"),  vec![TokenKind::OrOr]);
+        assert_eq!(scan("++"),  vec![TokenKind::PlusPlus]);
+        assert_eq!(scan("--"),  vec![TokenKind::MinusMinus]);
+        assert_eq!(scan("+="),  vec![TokenKind::PlusEqual]);
+        assert_eq!(scan("-="),  vec![TokenKind::MinusEqual]);
+        assert_eq!(scan("*="),  vec![TokenKind::StarEqual]);
+        assert_eq!(scan("/="),  vec![TokenKind::SlashEqual]);
+        assert_eq!(scan("->"),  vec![TokenKind::Arrow]);
+        assert_eq!(scan("<<"),  vec![TokenKind::LessLess]);
+        assert_eq!(scan(">>"),  vec![TokenKind::GreaterGreater]);
+        assert_eq!(scan(">>="), vec![TokenKind::GreaterGreaterEqual]);
+        assert_eq!(scan("<<="), vec![TokenKind::LessLessEqual]);
+    }
+
+    // --- Comentários de bloco ---
+
+    #[test]
+    fn multi_line_comment_skipped() {
+        let kinds = scan("42 /* este é um comentário\n de bloco */ 99");
+        assert_eq!(
+            kinds,
+            vec![TokenKind::IntLiteral(42), TokenKind::IntLiteral(99)]
+        );
+    }
+
+    #[test]
+    fn unclosed_block_comment_errors() {
+        let src = SourceFile::from_string("42 /* comentário não fechado");
+        let mut scanner = Scanner::new(src);
+        scanner.scan();
+
+        // Deve ter exatamente um diagnóstico de comentário não fechado
+        assert_eq!(scanner.diagnostics.len(), 1);
+
+        // O token 42 ainda foi emitido antes do comentário
+        assert_eq!(scanner.tokens[0].kind, TokenKind::IntLiteral(42));
+    }
 }

--- a/src/tests/lexical_test.rs
+++ b/src/tests/lexical_test.rs
@@ -160,6 +160,26 @@ mod tests {
     }
 
     #[test]
+    fn mismatched_delimiter_emits_diagnostic() {
+        // '{' abre mas ')' fecha — mismatch deve gerar diagnóstico
+        let src = SourceFile::from_string("{)");
+        let mut scanner = Scanner::new(src);
+        scanner.scan();
+
+        // Um UnexpectedClosingDelimiter(')') + Um UnclosedDelimiter('{')
+        assert_eq!(scanner.diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn unexpected_closing_with_empty_stack_emits_diagnostic() {
+        let src = SourceFile::from_string(")");
+        let mut scanner = Scanner::new(src);
+        scanner.scan();
+
+        assert_eq!(scanner.diagnostics.len(), 1);
+    }
+
+    #[test]
     fn unclosed_block_comment_errors() {
         let src = SourceFile::from_string("42 /* comentário não fechado");
         let mut scanner = Scanner::new(src);


### PR DESCRIPTION
## Descrição 

Resolve a issue #6. Implementa o reconhecimento completo de operadores simples e compostos no lexer, suporte a comentários de bloco /* */ com detecção de erro para blocos não fechados, e rastreamento de delimitadores abertos sem fechamento.

--- 

## Mudanças
src/common/errors/types.rs
Refatoração de LexicalError: o campo invalid_char: char foi substituído por kind: LexicalErrorKind, uma nova enum com três variantes:

---

InvalidChar(char) — comportamento anterior preservado
UnclosedBlockComment — comentário /* sem */
UnclosedDelimiter(char) — delimitador aberto sem fechamento
src/lexer/tokens/token_kind.rs
Adicionados os quatro tokens de shift que estavam faltando: LessLess (<<), GreaterGreater (>>), LessLessEqual (<<=), GreaterGreaterEqual (>>=).

---

src/lexer/rules/operators.rs (arquivo novo)
Trait OperatorRules implementada para Scanner. Contém a lógica de lookahead para todos os operadores da linguagem — ao consumir o primeiro caractere, verifica o próximo antes de decidir qual TokenKind emitir.

src/lexer/rules/mod.rs
Exposição do novo módulo operators.

src/lexer/scanner.rs

---

Operadores (+ - * / = ! < > & |) agora roteados para lex_operator em vez de emit_unknown
Adicionado delimiter_stack: Vec<(char, usize, usize)> para rastrear a posição de cada ( [ { aberto; ao atingir o EOF, itens restantes na pilha geram diagnósticos UnclosedDelimiter
skip_whitespaces_and_comments estendido com suporte a /* */; bloco sem fechamento gera diagnóstico UnclosedBlockComment
Skip de diretivas de pré-processador (#include, #define, etc.)
src/tests/lexical_test.rs
Três testes adicionados conforme especificado na issue:

lex_compound_operators — valida todos os 17 operadores compostos
multi_line_comment_skipped — valida que /* */ multilinha é ignorado
unclosed_block_comment_errors — valida diagnóstico para /* sem */
Testes
test result: ok. 39 passed; 0 failed

--- 

Closes #6 