### PR TITLE
fix(lexer): Validação de Dígitos Octais no Lexer

### DIFF
--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -36,6 +36,8 @@ pub enum LexicalErrorKind {
     UnexpectedClosingDelimiter(char),
     /// String ou char literal não fechada (ex: `"hello` sem `"`)
     UnterminatedLiteral(String),
+    /// Dígito inválido 8 e 9 para Octal
+    InvalidOctalDigit(char),
 }
 
 #[derive(Debug)]
@@ -71,6 +73,11 @@ impl ToReport for LexicalError {
                 .with_span(self.span.clone())
                 .with_label(self.span.clone(), format!("literal '{}' nao foi terminada", lit))
                 .with_help("Feche a string ou char corretamente."),
+            
+            LexicalErrorKind::InvalidOctalDigit(c) => Report::new("invalid octal digit")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), format!("'{}' nao e um digito octal valido", c))
+                .with_help("Numeros que comecam com '0' sao tratados como octais. Use apenas digitos de 0 a 7."),
         }
     }
 }

--- a/src/lexer/rules/literals.rs
+++ b/src/lexer/rules/literals.rs
@@ -1,6 +1,8 @@
 use crate::common::utils::char_utils::*;
 use crate::lexer::scanner::Scanner;
 use crate::lexer::tokens::TokenKind;
+use crate::common::errors::error_data::Span;
+use crate::common::errors::types::{CompilerError, LexicalError, LexicalErrorKind};
 
 pub trait LiteralsRules {
     fn lex_number(&mut self, first: char, line: usize, col: usize);
@@ -35,7 +37,7 @@ impl LiteralsRules for Scanner {
 
         // OCTAL: 0755, ...
         // If Responsavel para resolver os Hexadecimais
-        if first == '0' && matches!(self.src.peek(), Some('0'..='7')) {
+        if first == '0'{
             // Consome todos os digitos do OCTAL
             while let Some(c) = self.src.peek() {
                 if is_octal_digit(c) {
@@ -44,6 +46,27 @@ impl LiteralsRules for Scanner {
                 } else {
                     break;
                 }
+            }
+
+            // Se o proximo carctere é 8 ou 9, armazene em 'c' sem consumi-lo
+            if let Some(c @ ('8' | '9')) = self.src.peek(){
+                let error_col = self.src.col(); // Pego a coluna que está o 8/9
+                self.src.advance(); // consumo o 8/9, para não passar novamente pelo scanner
+
+                self.diagnostics.push(CompilerError::Lexical(LexicalError{ // relatório de erro: posição ee tipo
+                    span: Span{
+                        line,
+                        column_start: error_col,
+                        column_end: error_col + 1,
+                    },
+                    kind: LexicalErrorKind::InvalidOctalDigit(c),
+                }));
+
+                return self.emit_at(TokenKind::Unknown(c), &c.to_string(), line, error_col); // classifica como erro para não passar pra próxima fase:
+            }                                                                                // passando o digito inválido com string e sua posição       
+
+            if buf.len() == 1{
+                return self.emit_at(TokenKind::IntLiteral(0), &buf, line, col);
             }
             // Converte na base 8 pulando o 0 inicial
             let value = i64::from_str_radix(&buf[1..], 8).unwrap_or(0);
@@ -117,7 +140,6 @@ impl LiteralsRules for Scanner {
             match self.src.advance() {
                 Some('"') => {
                     lexeme.push('"');
-                    col_end += 1;
                     break;
                 }
                 Some('\\') => {
@@ -178,7 +200,7 @@ impl LiteralsRules for Scanner {
         match self.src.advance() {
             Some('\'') => {
                 lexeme.push('\'');
-                col_end += 1;
+             
                 self.emit_at(TokenKind::CharLiteral(c), &lexeme, line, col);
             }
             Some(err) => self.emit_unknown(err, line, col),

--- a/src/tests/lexical_test.rs
+++ b/src/tests/lexical_test.rs
@@ -3,6 +3,7 @@ mod tests {
     use crate::common::input::source::SourceFile;
     use crate::lexer::scanner::Scanner;
     use crate::lexer::tokens::token_kind::TokenKind;
+    // use crate::common::errors::types::{CompilerError, LexicalError, LexicalErrorKind};
 
     // Helper que tokeniza uma string e devolve só os kinds, sem o Eof.
     // Evita repetição nos testes — cada teste foca só no que importa.
@@ -190,5 +191,25 @@ mod tests {
 
         // O token 42 ainda foi emitido antes do comentário
         assert_eq!(scanner.tokens[0].kind, TokenKind::IntLiteral(42));
+    }
+
+    #[test]
+    fn invalid_octal_digit(){
+        let src = SourceFile::from_string("08");
+        let mut scanner = Scanner::new(src);
+        scanner.scan();
+
+        assert_eq!(scanner.diagnostics.len(), 1); // verificação se ele capturou o erro
+        
+        if let crate::common::errors::types::CompilerError::Lexical(ref err) = scanner.diagnostics[0]{ // resgatamos o erro
+            if let crate::common::errors::types::LexicalErrorKind::InvalidOctalDigit(c) = err.kind{// verificação se condiz a classificação certa
+                assert_eq!(c, '8');
+            } 
+            else{
+                panic!("Esperava InvalidOctalDigit, mas achou {:?}", err.kind);
+            }
+        }
+
+        assert_eq!(scanner.tokens[0].kind, TokenKind::Unknown('8')); // verificação se o 8 foi convertido para um token Unknow
     }
 }


### PR DESCRIPTION
# Review de Pull Request: Validação de Dígitos Octais no Lexer
## 1. O Problema: Emissão Silenciosa de Dígitos Inválidos

Anteriormente, o scanner tratava numerais iniciados em 0 como octais, mas ao encontrar os dígitos 8 ou 9 (inválidos na base 8), ele encerrava o token atual e iniciava um novo token decimal.

    Exemplo: 08 produzia IntLiteral(0) + IntLiteral(8), o que gerava erros sintáticos confusos no Parser ou resultados matemáticos incorretos.

## 2. Solução Técnica: Interceptação e Diagnóstico

A lógica do método lex_number foi ajustada para identificar quando o programador entra no "modo octal" (iniciando com 0).

    Validação: Após consumir os dígitos octais válidos (0-7), o Lexer agora realiza um lookahead (peek) para verificar se o próximo caractere é 8 ou 9.

    Recuperação de Erro: Caso um dígito inválido seja detectado, o scanner emite um diagnóstico de erro léxico, consome o caractere para evitar loops infinitos e retorna um TokenKind::Unknown.

## 3. Teste de Validação: invalid_octal_digit

Foi implementado um teste unitário para garantir que a correção está funcional e que o sistema de diagnósticos está reportando os dados corretamente.

Resultado do Teste:

    Entrada: "08"

    Diagnósticos: 1 erro capturado (InvalidOctalDigit('8')).

    Tokens: O dígito 8 foi convertido em Unknown('8') para isolar o erro.


```Rust
#[test]
fn invalid_octal_digit_emits_diagnostic() {
    let src = SourceFile::from_string("08");
    let mut scanner = Scanner::new(src);
    scanner.scan();

    // Garante que o erro foi registrado
    assert_eq!(scanner.diagnostics.len(), 1);

    // Valida se o caractere infrator foi capturado corretamente
    if let crate::common::errors::types::CompilerError::Lexical(ref err) = scanner.diagnostics[0] {
        if let crate::common::errors::types::LexicalErrorKind::InvalidOctalDigit(c) = err.kind {
            assert_eq!(c, '8');
        }
    }
}
```
## 4. Atualização nos Reports (UI de Erro)

Adicionado suporte no ToReport para que o erro de dígito octal apresente uma sugestão clara ao desenvolvedor, explicando que numerais iniciados com 0 são tratados como base 8.

### OBS.: Retirei o col_end das linhas 143 e 204 em src/lexer/rules/literals.rs, com base nos avisos do compilador Cargo: de não utilização dessas variáveis.

Fixes #56