### PR TITLE
fix(lexer): detecta char literal vazio '' como erro (#57)

### DIFF
--- a/src/lexer/rules/literals.rs
+++ b/src/lexer/rules/literals.rs
@@ -147,6 +147,13 @@ impl LiteralsRules for Scanner {
         let mut lexeme = String::from('\'');
         let mut col_end = col + 1;
 
+        // '' é inválido em C — char literal vazio
+        if self.src.peek() == Some('\'') {
+            self.src.advance(); // consome o fechamento imediato
+            self.emit_unterminated_literal("char", line, col, col_end);
+            return;
+        }
+
         let c = match self.src.advance() {
             Some('\\') => {
                 lexeme.push('\\');

--- a/src/tests/literals_test.rs
+++ b/src/tests/literals_test.rs
@@ -29,4 +29,18 @@ mod tests {
             .any(|e| format!("{:?}", e).contains("UnterminatedLiteral"));
         assert!(found, "Deveria detectar char não terminado");
     }
+
+    #[test]
+    fn empty_char_literal() {
+        let scanner = scan_source("''");
+        assert!(
+            scanner.diagnostics.len() >= 1,
+            "Deveria detectar char literal vazio"
+        );
+        let found = scanner
+            .diagnostics
+            .iter()
+            .any(|e| format!("{:?}", e).contains("UnterminatedLiteral"));
+        assert!(found, "Diagnostico deve ser UnterminatedLiteral");
+    }
 }


### PR DESCRIPTION
## Descricao

- Esse PR corrige o erro de nao deteccao do char literal vazio ' ' como erro

- Adiciona guarda no início de lex_char: se o próximo char for ''',

- consome e emite UnterminatedLiteral("char") imediatamente

- Adiciona teste empty_char_literal em literals_test.rs

---

Closes #57 