### PR TITLE
feat(parser): implementa parse_if, parse_while e parse_do_while

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo test
 
 ```bash
 cargo test lexical      # testes do scanner/lexer (21 casos)
-cargo test parser       # testes do parser / AST (30 casos)
+cargo test parser       # testes do parser / AST
 cargo test literals     # testes de literais numéricos (4 casos)
 cargo test token        # testes de tokens individuais (2 casos)
 cargo test source       # testes de SourceFile e spans (12 casos)
@@ -89,7 +89,7 @@ cargo test -- --nocapture
 | Nome                  | GitHub / contato                    |
 |-----------------------|-------------------------------------|
 | Lucas Andrade Zanetti | [@Bappoz](https://github.com/Bappoz) |
-| Gustavo               | [@guxvr](https://github.com/guxvr)  |
+| Gustavo Xavier        | [@guxvr](https://github.com/guxvr)  |
 | Hugo Freitas Silva    | [@HugoFreitass](https://github.com/HugoFreitass) |
 | Matheus Lemes         | [@matheuslemesam](https://github.com/matheuslemesam) |
 | Philipe Caetano       | philipe2015amancio@hotmail.com      |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo test
 
 ```bash
 cargo test lexical      # testes do scanner/lexer (21 casos)
-cargo test parser       # testes do parser / AST (12 casos)
+cargo test parser       # testes do parser / AST (30 casos)
 cargo test literals     # testes de literais numéricos (4 casos)
 cargo test token        # testes de tokens individuais (2 casos)
 cargo test source       # testes de SourceFile e spans (12 casos)
@@ -79,7 +79,7 @@ cargo test -- --nocapture
 | `src/tests/lexical_test.rs`   | Scanner: operadores, palavras-chave, literais  | 21     |
 | `src/tests/source_test.rs`    | `SourceFile`, `ByteSpan`, posicionamento       | 12     |
 | `src/tests/lexer_file_test.rs`| Scanner sobre arquivos reais                   | 7      |
-| `src/tests/parser_test.rs`    | Parser / construção de AST                     | 12     |
+| `src/tests/parser_test.rs`    | Parser / construção de AST                     | 30     |
 | `src/tests/literals_test.rs`  | Literais inteiros, floats, strings             | 4      |
 | `src/tests/ast_errors.rs`     | Diagnósticos e erros de AST                    | 4      |
 | `src/tests/token_test.rs`     | `Token` e `TokenKind`                          | 2      |

--- a/src/common/ast/stmt.rs
+++ b/src/common/ast/stmt.rs
@@ -13,7 +13,7 @@ pub enum Stmt {
         Box<Stmt>,
         Span,
     ), // For(Init, Cond, Inc, Body, Span)
-    DoWhile(Box<Stmt>, Expr, Span),
+    DoWhile(Expr, Box<Stmt>, Span),
     Break(Span),
     Continue(Span),
     ExprStmt(Expr, Span),

--- a/src/common/ast/stmt.rs
+++ b/src/common/ast/stmt.rs
@@ -13,6 +13,7 @@ pub enum Stmt {
         Box<Stmt>,
         Span,
     ), // For(Init, Cond, Inc, Body, Span)
+    DoWhile(Box<Stmt>, Expr, Span),
     Break(Span),
     Continue(Span),
     ExprStmt(Expr, Span),
@@ -28,6 +29,7 @@ impl Stmt {
             Stmt::If(_, _, _, s) => s.clone(),
             Stmt::While(_, _, s) => s.clone(),
             Stmt::For(_, _, _, _, s) => s.clone(),
+            Stmt::DoWhile(_, _, s) => s.clone(),
             Stmt::Break(s) => s.clone(),
             Stmt::Continue(s) => s.clone(),
             Stmt::ExprStmt(_, s) => s.clone(),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -4,7 +4,6 @@ use crate::common::errors::error_data::Span;
 use crate::common::errors::types::{CompilerError, SyntaxError};
 use crate::lexer::tokens::token::Token;
 use crate::lexer::tokens::token_kind::TokenKind;
-use crate::parser::rules::declarations;
 use crate::parser::rules::expressions::{infix, postfix, prefix};
 
 // TODO(parser): manter somente o parser de expressoes neste arquivo por enquanto.
@@ -76,18 +75,9 @@ impl Parser {
         Ok(lhs)
     }
 
-    /// Dispatcher do statement: declaracao de variavel ou expression-statement
+    /// Dispatcher de statements: delega para o parser completo de statements.
     pub fn parse_stmt(&mut self) -> Result<Stmt, Diagnostic> {
-        if declarations::starts_type(self.peek_kind()) {
-            return declarations::parse_var_decl(self);
-        }
-
-        let expr = self.parse_expr(0)?;
-        let semi = self
-            .expect(&TokenKind::Semicolon, "';' ao fim do statement")?
-            .clone();
-        let span = self.join_span(expr.span(), self.span_of(&semi));
-        Ok(Stmt::ExprStmt(expr, span))
+        crate::parser::rules::statements::parse_stmt(self)
     }
 
     /// Retorna o token atual sem avançar a posição.

--- a/src/parser/rules/declarations/var_decl.rs
+++ b/src/parser/rules/declarations/var_decl.rs
@@ -29,7 +29,7 @@ pub fn parse_var_decl(parser: &mut Parser) -> Result<Stmt, CompilerError> {
     };
 
     let semi = parser
-        .expect(&TokenKind::Semicolon, "';' ao fim da declaracao")?
+        .expect(&TokenKind::Semicolon, "';' ao fim da declaração")?
         .clone();
     let span = parser.join_span(parser.span_of(&start), parser.span_of(&semi));
 

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -2,6 +2,7 @@ use crate::common::ast::stmt::Stmt;
 use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
+use crate::parser::rules::declarations;
 
 /// Dispatcher principal: decide qual parser de statement usar com base no token atual.
 ///
@@ -19,13 +20,12 @@ pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         TokenKind::If => parse_if(parser),
         TokenKind::While => parse_while(parser),
         TokenKind::Do => parse_do_while(parser),
-        _ => {
-            if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
-                crate::parser::rules::declarations::parse_var_decl(parser)
-            } else {
-                parse_expr_stmt(parser)
-            }
+        TokenKind::For => {
+            let tok = parser.peek().clone();
+            Err(parser.syntax_error(&tok, "statement", "'for' ainda não implementado"))
         }
+        _ if declarations::starts_type(parser.peek_kind()) => declarations::parse_var_decl(parser),
+        _ => parse_expr_stmt(parser),
     }
 }
 
@@ -139,7 +139,7 @@ fn parse_do_while(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         .clone();
 
     let span = parser.join_span(parser.span_of(&kw), parser.span_of(&semi));
-    Ok(Stmt::DoWhile(Box::new(body), cond, span))
+    Ok(Stmt::DoWhile(cond, Box::new(body), span))
 }
 
 /// Parseia qualquer expressão seguida de `;`.

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -5,18 +5,27 @@ use crate::parser::parser::Parser;
 
 /// Dispatcher principal: decide qual parser de statement usar com base no token atual.
 ///
-/// Nesta iteração (PARSER-01) reconhece apenas:
+/// Reconhece:
 ///   `{` → bloco, `return` → return, `break` → break, `continue` → continue,
+///   `if` → if, `while` → while, `do` → do-while,
+///   keywords de tipo → declaração de variável,
 ///   qualquer outra coisa → statement de expressão.
-/// Palavras-chave de controle de fluxo (`if`, `while`, `for`) e declarações de
-/// variáveis serão adicionadas nas issues subsequentes.
 pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
     match parser.peek_kind().clone() {
         TokenKind::LeftBrace => parse_block(parser),
         TokenKind::Return => parse_return(parser),
         TokenKind::Break => parse_break(parser),
         TokenKind::Continue => parse_continue(parser),
-        _ => parse_expr_stmt(parser),
+        TokenKind::If => parse_if(parser),
+        TokenKind::While => parse_while(parser),
+        TokenKind::Do => parse_do_while(parser),
+        _ => {
+            if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
+                crate::parser::rules::declarations::parse_var_decl(parser)
+            } else {
+                parse_expr_stmt(parser)
+            }
+        }
     }
 }
 
@@ -74,6 +83,63 @@ fn parse_continue(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         .clone();
     let span = parser.join_span(parser.span_of(&kw), parser.span_of(&semi));
     Ok(Stmt::Continue(span))
+}
+
+/// Parseia `if (expr) stmt [else stmt]`.
+/// Suporta `else if` via recursão natural (o `else` chama `parse_stmt` novamente).
+fn parse_if(parser: &mut Parser) -> Result<Stmt, CompilerError> {
+    let kw = parser.expect(&TokenKind::If, "'if'")?.clone();
+
+    parser.expect(&TokenKind::LeftParen, "'(' após if")?;
+    let cond = parser.parse_expr(0)?;
+    parser.expect(&TokenKind::RightParen, "')' após condição do if")?;
+
+    let then_branch = parse_stmt(parser)?;
+
+    let else_branch = if parser.match_kind(&TokenKind::Else) {
+        Some(Box::new(parse_stmt(parser)?))
+    } else {
+        None
+    };
+
+    let end = else_branch
+        .as_ref()
+        .map(|e| e.span())
+        .unwrap_or_else(|| then_branch.span());
+    let span = parser.join_span(parser.span_of(&kw), end);
+    Ok(Stmt::If(cond, Box::new(then_branch), else_branch, span))
+}
+
+/// Parseia `while (expr) stmt`.
+fn parse_while(parser: &mut Parser) -> Result<Stmt, CompilerError> {
+    let kw = parser.expect(&TokenKind::While, "'while'")?.clone();
+
+    parser.expect(&TokenKind::LeftParen, "'(' após while")?;
+    let cond = parser.parse_expr(0)?;
+    parser.expect(&TokenKind::RightParen, "')' após condição do while")?;
+
+    let body = parse_stmt(parser)?;
+
+    let span = parser.join_span(parser.span_of(&kw), body.span());
+    Ok(Stmt::While(cond, Box::new(body), span))
+}
+
+/// Parseia `do stmt while (expr);`.
+fn parse_do_while(parser: &mut Parser) -> Result<Stmt, CompilerError> {
+    let kw = parser.expect(&TokenKind::Do, "'do'")?.clone();
+
+    let body = parse_stmt(parser)?;
+
+    parser.expect(&TokenKind::While, "'while' após corpo do do")?;
+    parser.expect(&TokenKind::LeftParen, "'(' após while do do-while")?;
+    let cond = parser.parse_expr(0)?;
+    parser.expect(&TokenKind::RightParen, "')' após condição do do-while")?;
+    let semi = parser
+        .expect(&TokenKind::Semicolon, "';' após do-while")?
+        .clone();
+
+    let span = parser.join_span(parser.span_of(&kw), parser.span_of(&semi));
+    Ok(Stmt::DoWhile(Box::new(body), cond, span))
 }
 
 /// Parseia qualquer expressão seguida de `;`.

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -11,7 +11,7 @@ use crate::parser::parser::Parser;
 ///   keywords de tipo → declaração de variável,
 ///   qualquer outra coisa → statement de expressão.
 pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
-    match parser.peek_kind().clone() {
+    match parser.peek_kind() {
         TokenKind::LeftBrace => parse_block(parser),
         TokenKind::Return => parse_return(parser),
         TokenKind::Break => parse_break(parser),

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -617,7 +617,7 @@ mod tests {
         ];
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("do-while válido");
-        let Stmt::DoWhile(body, cond, _) = stmt else {
+        let Stmt::DoWhile(cond, body, _) = stmt else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
@@ -643,7 +643,7 @@ mod tests {
         ];
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("do-while com bloco válido");
-        let Stmt::DoWhile(body, cond, _) = stmt else {
+        let Stmt::DoWhile(cond, body, _) = stmt else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::Block(stmts, _) = *body else {
@@ -651,5 +651,48 @@ mod tests {
         };
         assert!(matches!(&stmts[0], Stmt::Break(_)));
         assert!(matches!(cond, Expr::Literal(Literal::Int(1), _)));
+    }
+
+    #[test]
+    fn rejects_if_missing_right_paren() {
+        // if (x { return; }  — falta ')'
+        let tokens = vec![
+            tk(TokenKind::If, 1),
+            tk(TokenKind::LeftParen, 4),
+            ident("x", 5),
+            tk(TokenKind::LeftBrace, 7),
+            eof(8),
+        ];
+        assert!(Parser::new(tokens).parse_stmt().is_err());
+    }
+
+    #[test]
+    fn rejects_while_missing_left_paren() {
+        // while x > 0)  — falta '('
+        let tokens = vec![
+            tk(TokenKind::While, 1),
+            ident("x", 7),
+            tk(TokenKind::Greater, 9),
+            int(0, 11),
+            tk(TokenKind::RightParen, 12),
+            eof(13),
+        ];
+        assert!(Parser::new(tokens).parse_stmt().is_err());
+    }
+
+    #[test]
+    fn rejects_do_while_missing_semicolon() {
+        // do { } while (1)  — falta ';'
+        let tokens = vec![
+            tk(TokenKind::Do, 1),
+            tk(TokenKind::LeftBrace, 4),
+            tk(TokenKind::RightBrace, 5),
+            tk(TokenKind::While, 7),
+            tk(TokenKind::LeftParen, 13),
+            int(1, 14),
+            tk(TokenKind::RightParen, 15),
+            eof(16),
+        ];
+        assert!(Parser::new(tokens).parse_stmt().is_err());
     }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -537,4 +537,235 @@ mod tests {
         assert!(matches!(qty.ty, Type::Pointer(_)));
         assert_eq!(name, "p");
     }
+
+    #[test]
+    fn parses_if_without_else() {
+        // if (x > 0) return x;
+        let tokens = vec![
+            tk(TokenKind::If, 1),
+            tk(TokenKind::LeftParen, 4),
+            ident("x", 5),
+            tk(TokenKind::Greater, 7),
+            int(0, 9),
+            tk(TokenKind::RightParen, 10),
+            tk(TokenKind::Return, 12),
+            ident("x", 19),
+            tk(TokenKind::Semicolon, 20),
+            eof(21),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("if válido");
+        let Stmt::If(cond, then_branch, None, _) = stmt else {
+            panic!("esperava Stmt::If sem else");
+        };
+        assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
+        let Stmt::Return(Some(ret_expr), _) = *then_branch else {
+            panic!("esperava return no then-branch");
+        };
+        assert!(matches!(ret_expr, Expr::Ident(name, _) if name == "x"));
+    }
+
+    #[test]
+    fn parses_if_with_else() {
+        // if (x) return 1; else return 0;
+        let tokens = vec![
+            tk(TokenKind::If, 1),
+            tk(TokenKind::LeftParen, 4),
+            ident("x", 5),
+            tk(TokenKind::RightParen, 6),
+            tk(TokenKind::Return, 8),
+            int(1, 15),
+            tk(TokenKind::Semicolon, 16),
+            tk(TokenKind::Else, 18),
+            tk(TokenKind::Return, 23),
+            int(0, 30),
+            tk(TokenKind::Semicolon, 31),
+            eof(32),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("if-else válido");
+        let Stmt::If(cond, _, Some(else_branch), _) = stmt else {
+            panic!("esperava Stmt::If com else");
+        };
+        assert!(matches!(cond, Expr::Ident(name, _) if name == "x"));
+        let Stmt::Return(Some(ret_expr), _) = *else_branch else {
+            panic!("esperava return no else-branch");
+        };
+        assert!(matches!(ret_expr, Expr::Literal(Literal::Int(0), _)));
+    }
+
+    #[test]
+    fn parses_if_else_if_chain() {
+        // if (a) return 1; else if (b) return 2;
+        let tokens = vec![
+            tk(TokenKind::If, 1),
+            tk(TokenKind::LeftParen, 4),
+            ident("a", 5),
+            tk(TokenKind::RightParen, 6),
+            tk(TokenKind::Return, 8),
+            int(1, 15),
+            tk(TokenKind::Semicolon, 16),
+            tk(TokenKind::Else, 18),
+            tk(TokenKind::If, 23),
+            tk(TokenKind::LeftParen, 26),
+            ident("b", 27),
+            tk(TokenKind::RightParen, 28),
+            tk(TokenKind::Return, 30),
+            int(2, 37),
+            tk(TokenKind::Semicolon, 38),
+            eof(39),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("if-else-if válido");
+        let Stmt::If(_, _, Some(else_branch), _) = stmt else {
+            panic!("esperava Stmt::If com else");
+        };
+        let Stmt::If(inner_cond, _, None, _) = *else_branch else {
+            panic!("esperava Stmt::If aninhado no else");
+        };
+        assert!(matches!(inner_cond, Expr::Ident(name, _) if name == "b"));
+    }
+
+    #[test]
+    fn parses_if_with_block() {
+        // if (x > 0) { return x; }
+        let tokens = vec![
+            tk(TokenKind::If, 1),
+            tk(TokenKind::LeftParen, 4),
+            ident("x", 5),
+            tk(TokenKind::Greater, 7),
+            int(0, 9),
+            tk(TokenKind::RightParen, 10),
+            tk(TokenKind::LeftBrace, 12),
+            tk(TokenKind::Return, 14),
+            ident("x", 21),
+            tk(TokenKind::Semicolon, 22),
+            tk(TokenKind::RightBrace, 24),
+            eof(25),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("if com bloco válido");
+        let Stmt::If(cond, then_branch, None, _) = stmt else {
+            panic!("esperava Stmt::If sem else");
+        };
+        assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
+        let Stmt::Block(stmts, _) = *then_branch else {
+            panic!("esperava bloco no then-branch");
+        };
+        assert_eq!(stmts.len(), 1);
+    }
+
+    #[test]
+    fn parses_while_stmt() {
+        // while (x > 0) x = x - 1;
+        let tokens = vec![
+            tk(TokenKind::While, 1),
+            tk(TokenKind::LeftParen, 7),
+            ident("x", 8),
+            tk(TokenKind::Greater, 10),
+            int(0, 12),
+            tk(TokenKind::RightParen, 13),
+            ident("x", 15),
+            tk(TokenKind::Equal, 17),
+            ident("x", 19),
+            tk(TokenKind::Minus, 21),
+            int(1, 23),
+            tk(TokenKind::Semicolon, 24),
+            eof(25),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("while válido");
+        let Stmt::While(cond, body, _) = stmt else {
+            panic!("esperava Stmt::While");
+        };
+        assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
+        let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
+            panic!("esperava ExprStmt com atribuição no corpo do while");
+        };
+    }
+
+    #[test]
+    fn parses_while_with_block() {
+        // while (1) { break; }
+        let tokens = vec![
+            tk(TokenKind::While, 1),
+            tk(TokenKind::LeftParen, 7),
+            int(1, 8),
+            tk(TokenKind::RightParen, 9),
+            tk(TokenKind::LeftBrace, 11),
+            tk(TokenKind::Break, 13),
+            tk(TokenKind::Semicolon, 18),
+            tk(TokenKind::RightBrace, 20),
+            eof(21),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("while com bloco válido");
+        let Stmt::While(cond, body, _) = stmt else {
+            panic!("esperava Stmt::While");
+        };
+        assert!(matches!(cond, Expr::Literal(Literal::Int(1), _)));
+        let Stmt::Block(stmts, _) = *body else {
+            panic!("esperava bloco no corpo do while");
+        };
+        assert!(matches!(&stmts[0], Stmt::Break(_)));
+    }
+
+    #[test]
+    fn parses_do_while_stmt() {
+        // do x = x + 1; while (x < 10);
+        let tokens = vec![
+            tk(TokenKind::Do, 1),
+            ident("x", 4),
+            tk(TokenKind::Equal, 6),
+            ident("x", 8),
+            tk(TokenKind::Plus, 10),
+            int(1, 12),
+            tk(TokenKind::Semicolon, 13),
+            tk(TokenKind::While, 15),
+            tk(TokenKind::LeftParen, 21),
+            ident("x", 22),
+            tk(TokenKind::Less, 24),
+            int(10, 26),
+            tk(TokenKind::RightParen, 28),
+            tk(TokenKind::Semicolon, 29),
+            eof(30),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("do-while válido");
+        let Stmt::DoWhile(body, cond, _) = stmt else {
+            panic!("esperava Stmt::DoWhile");
+        };
+        let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
+            panic!("esperava ExprStmt com atribuição no corpo do do-while");
+        };
+        assert!(matches!(cond, Expr::Binary(_, BinOp::Less, _, _)));
+    }
+
+    #[test]
+    fn parses_do_while_with_block() {
+        // do { break; } while (1);
+        let tokens = vec![
+            tk(TokenKind::Do, 1),
+            tk(TokenKind::LeftBrace, 4),
+            tk(TokenKind::Break, 6),
+            tk(TokenKind::Semicolon, 11),
+            tk(TokenKind::RightBrace, 13),
+            tk(TokenKind::While, 15),
+            tk(TokenKind::LeftParen, 21),
+            int(1, 22),
+            tk(TokenKind::RightParen, 23),
+            tk(TokenKind::Semicolon, 24),
+            eof(25),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parse_stmt(&mut parser).expect("do-while com bloco válido");
+        let Stmt::DoWhile(body, cond, _) = stmt else {
+            panic!("esperava Stmt::DoWhile");
+        };
+        let Stmt::Block(stmts, _) = *body else {
+            panic!("esperava bloco no corpo do do-while");
+        };
+        assert!(matches!(&stmts[0], Stmt::Break(_)));
+        assert!(matches!(cond, Expr::Literal(Literal::Int(1), _)));
+    }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -308,11 +308,11 @@ mod tests {
     fn parses_block_with_return_from_full_code1() {
         let tokens = vec![
             tk(TokenKind::LeftBrace, 1),
-            tk(TokenKind::Return, 5),
-            ident("x", 12),
-            tk(TokenKind::Semicolon, 13),
-            tk(TokenKind::RightBrace, 5),
-            eof(6),
+            tk(TokenKind::Return, 3),
+            ident("x", 10),
+            tk(TokenKind::Semicolon, 11),
+            tk(TokenKind::RightBrace, 13),
+            eof(14),
         ];
 
         let mut parser = Parser::new(tokens);

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -8,7 +8,6 @@ mod tests {
     use crate::lexer::tokens::token_kind::TokenKind;
     use crate::parser::Parser;
 
-    // Helper para criar tokens compactos nos testes sem depender do scanner.
     fn tk(kind: TokenKind, col: usize) -> Token {
         Token {
             kind,
@@ -30,9 +29,6 @@ mod tests {
         tk(TokenKind::Eof, col)
     }
 
-    // ── testes de expressão ──────────────────────────────────────────────────
-
-    // Garante que precedência de multiplicação vence soma: 1 + 2 * 3.
     #[test]
     fn parses_precedence_in_expression() {
         let tokens = vec![
@@ -46,22 +42,15 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let expr = parser.parse_expr(0).expect("expressão válida");
-        println!("[parses_precedence_in_expression] AST: {expr:#?}");
 
         let Expr::Binary(left, BinOp::Add, right, _) = expr else {
             panic!("esperava soma no topo da árvore");
         };
-        println!("[parses_precedence_in_expression] nó raiz = Add  ✓");
-        println!("[parses_precedence_in_expression] left  = {left:?}");
-        println!("[parses_precedence_in_expression] right = {right:?}");
 
         assert!(matches!(*left, Expr::Literal(Literal::Int(1), _)));
-        println!("[parses_precedence_in_expression] left é Literal(1)  ✓");
         assert!(matches!(*right, Expr::Binary(_, BinOp::Mul, _, _)));
-        println!("[parses_precedence_in_expression] right é Mul  ✓");
     }
 
-    // Garante respeito ao agrupamento com parênteses: (1 + 2) * 3.
     #[test]
     fn parses_grouped_expression() {
         let tokens = vec![
@@ -77,19 +66,13 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let expr = parser.parse_expr(0).expect("expressão válida");
-        println!("[parses_grouped_expression] AST: {expr:#?}");
 
         let Expr::Binary(left, BinOp::Mul, right, _) = expr else {
             panic!("esperava multiplicação no topo da árvore");
         };
-        println!("[parses_grouped_expression] nó raiz = Mul  ✓");
-        println!("[parses_grouped_expression] left  = {left:?}");
-        println!("[parses_grouped_expression] right = {right:?}");
 
         assert!(matches!(*right, Expr::Literal(Literal::Int(3), _)));
-        println!("[parses_grouped_expression] right é Literal(3)  ✓");
         assert!(matches!(*left, Expr::Binary(_, BinOp::Add, _, _)));
-        println!("[parses_grouped_expression] left é Add (grupo parênteses)  ✓");
     }
 
     #[test]
@@ -106,17 +89,10 @@ mod tests {
         for (tokens, kind) in cases {
             let mut parser = Parser::new(tokens);
             let expr = parser.parse_expr(0).expect("expressão válida");
-            println!("[parses_prefix_operators] caso '{kind}' => AST: {expr:?}");
             match (kind, expr) {
-                ("neg", Expr::Unary(_, _, _)) => {
-                    println!("[parses_prefix_operators] '-x' é Unary  ✓")
-                }
-                ("not", Expr::Unary(_, _, _)) => {
-                    println!("[parses_prefix_operators] '!x' é Unary  ✓")
-                }
-                ("inc", Expr::Prefix(PrefixOp::Inc, _, _)) => {
-                    println!("[parses_prefix_operators] '++x' é Prefix::Inc  ✓")
-                }
+                ("neg", Expr::Unary(_, _, _)) => {}
+                ("not", Expr::Unary(_, _, _)) => {}
+                ("inc", Expr::Prefix(PrefixOp::Inc, _, _)) => {}
                 _ => panic!("nó prefixo inesperado"),
             }
         }
@@ -147,28 +123,19 @@ mod tests {
         let first = Parser::new(cases[0].clone())
             .parse_expr(0)
             .expect("postfix válido");
-        println!("[parses_postfix_operators] 'x++' => {first:?}");
         assert!(matches!(first, Expr::Postfix(PostfixOp::Inc, _, _)));
-        println!("[parses_postfix_operators] 'x++' é Postfix::Inc  ✓");
 
         let second = Parser::new(cases[1].clone())
             .parse_expr(0)
             .expect("indexação válida");
-        println!("[parses_postfix_operators] 'x[0]' => {second:?}");
         assert!(matches!(second, Expr::Index(_, _, _)));
-        println!("[parses_postfix_operators] 'x[0]' é Index  ✓");
 
         let third = Parser::new(cases[2].clone())
             .parse_expr(0)
             .expect("chamada válida");
-        println!("[parses_postfix_operators] 'f(1,2)' => {third:?}");
         let Expr::Call(_, args, _) = third else {
             panic!("esperava chamada de função");
         };
-        println!(
-            "[parses_postfix_operators] 'f(1,2)' é Call com {} args  ✓",
-            args.len()
-        );
         assert_eq!(args.len(), 2);
     }
 
@@ -184,7 +151,6 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let expr = parser.parse_expr(0).expect("cast válido");
-        println!("[parses_cast_expression] AST: {expr:#?}");
 
         let Expr::Cast(
             QualifierType {
@@ -198,17 +164,11 @@ mod tests {
         else {
             panic!("esperava cast no topo da árvore");
         };
-        println!("[parses_cast_expression] Cast para ty={ty:?}  is_const={is_const}  is_unsigned={is_unsigned}");
 
         assert!(matches!(ty, Type::Int));
-        println!("[parses_cast_expression] ty é Int  ✓");
         assert!(!is_const);
-        println!("[parses_cast_expression] is_const=false  ✓");
         assert!(!is_unsigned);
-        println!("[parses_cast_expression] is_unsigned=false  ✓");
-        println!("[parses_cast_expression] inner = {inner:?}");
         assert!(matches!(*inner, Expr::Ident(_, _)));
-        println!("[parses_cast_expression] inner é Ident  ✓");
     }
 
     #[test]
@@ -222,18 +182,13 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let expr = parser.parse_expr(0).expect("atribuição válida");
-        println!("[parses_assignment_expression] AST: {expr:#?}");
 
         let Expr::Assign(lhs, rhs, _) = expr else {
             panic!("esperava atribuição no topo da árvore");
         };
-        println!("[parses_assignment_expression] lhs = {lhs:?}");
-        println!("[parses_assignment_expression] rhs = {rhs:?}");
 
         assert!(matches!(*lhs, Expr::Ident(_, _)));
-        println!("[parses_assignment_expression] lhs é Ident  ✓");
         assert!(matches!(*rhs, Expr::Ident(_, _)));
-        println!("[parses_assignment_expression] rhs é Ident  ✓");
     }
 
     #[test]
@@ -241,13 +196,9 @@ mod tests {
         let tokens = vec![int(1, 1), tk(TokenKind::Unknown('?'), 2), int(2, 3), eof(4)];
 
         let mut parser = Parser::new(tokens);
-        let result = parser.parse_expr(0);
-        println!("[rejects_invalid_operator_tokens] resultado: {result:?}");
-        assert!(result.is_err());
-        println!("[rejects_invalid_operator_tokens] erro esperado ao encontrar '?'  ✓");
+        assert!(parser.parse_expr(0).is_err());
     }
 
-    // Garante erro sintático quando falta fechar parêntese.
     #[test]
     fn reports_missing_right_paren() {
         let tokens = vec![
@@ -259,18 +210,11 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let result = parser.parse_expr(0);
-        println!("[reports_missing_right_paren] resultado: {result:?}");
-        assert!(result.is_err());
-        println!("[reports_missing_right_paren] erro esperado por ')' ausente  ✓");
+        assert!(parser.parse_expr(0).is_err());
     }
 
-    // ── testes de statements (PARSER-01) ────────────────────────────────────
-
-    /// `return x;` produz Stmt::Return com expressão Ident("x").
     #[test]
     fn parses_return_with_value() {
-        // return x ;  EOF
         let tokens = vec![
             tk(TokenKind::Return, 1),
             ident("x", 8),
@@ -280,17 +224,13 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("return válido");
-        println!("[parses_return_with_value] AST: {stmt:#?}");
 
         let Stmt::Return(Some(expr), _) = stmt else {
             panic!("esperava Stmt::Return com valor");
         };
-        println!("[parses_return_with_value] expr = {expr:?}");
         assert!(matches!(expr, Expr::Ident(ref s, _) if s == "x"));
-        println!("[parses_return_with_value] Stmt::Return(Ident(\"x\"))  ✓");
     }
 
-    /// `return;` produz Stmt::Return sem valor.
     #[test]
     fn parses_return_without_value() {
         let tokens = vec![
@@ -301,26 +241,20 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("return vazio válido");
-        println!("[parses_return_without_value] AST: {stmt:#?}");
 
         assert!(matches!(stmt, Stmt::Return(None, _)));
-        println!("[parses_return_without_value] Stmt::Return(None)  ✓");
     }
 
-    /// `break;` produz Stmt::Break.
     #[test]
     fn parses_break_statement() {
         let tokens = vec![tk(TokenKind::Break, 1), tk(TokenKind::Semicolon, 6), eof(7)];
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("break válido");
-        println!("[parses_break_statement] AST: {stmt:#?}");
 
         assert!(matches!(stmt, Stmt::Break(_)));
-        println!("[parses_break_statement] Stmt::Break  ✓");
     }
 
-    /// `continue;` produz Stmt::Continue.
     #[test]
     fn parses_continue_statement() {
         let tokens = vec![
@@ -331,13 +265,10 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("continue válido");
-        println!("[parses_continue_statement] AST: {stmt:#?}");
 
         assert!(matches!(stmt, Stmt::Continue(_)));
-        println!("[parses_continue_statement] Stmt::Continue  ✓");
     }
 
-    /// `x++;` produz Stmt::ExprStmt com Expr::Postfix.
     #[test]
     fn parses_expr_stmt_postfix_inc() {
         let tokens = vec![
@@ -349,17 +280,13 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("expr stmt válido");
-        println!("[parses_expr_stmt_postfix_inc] AST: {stmt:#?}");
 
         let Stmt::ExprStmt(expr, _) = stmt else {
             panic!("esperava ExprStmt");
         };
-        println!("[parses_expr_stmt_postfix_inc] expr = {expr:?}");
         assert!(matches!(expr, Expr::Postfix(PostfixOp::Inc, _, _)));
-        println!("[parses_expr_stmt_postfix_inc] ExprStmt(Postfix::Inc)  ✓");
     }
 
-    /// Bloco vazio `{}` produz Stmt::Block com zero statements.
     #[test]
     fn parses_empty_block() {
         let tokens = vec![
@@ -370,21 +297,15 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("bloco vazio válido");
-        println!("[parses_empty_block] AST: {stmt:#?}");
 
         let Stmt::Block(stmts, _) = stmt else {
             panic!("esperava Block");
         };
-        println!("[parses_empty_block] Block com {} statements", stmts.len());
         assert!(stmts.is_empty());
-        println!("[parses_empty_block] Block vazio  ✓");
     }
 
-    /// Bloco `{ return x; }` — reproduz o trecho de full_code1.c coberto por PARSER-01.
-    /// full_code1.c: `if (x > 0) { return x; }` — o corpo do if é um bloco com return.
     #[test]
     fn parses_block_with_return_from_full_code1() {
-        // { return x ; }  EOF
         let tokens = vec![
             tk(TokenKind::LeftBrace, 1),
             tk(TokenKind::Return, 5),
@@ -396,51 +317,30 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         let stmt = parser.parse_stmt().expect("bloco com return válido");
-        println!("[parses_block_with_return_from_full_code1] AST: {stmt:#?}");
 
         let Stmt::Block(stmts, _) = stmt else {
             panic!("esperava Block");
         };
-        println!(
-            "[parses_block_with_return_from_full_code1] Block com {} statements",
-            stmts.len()
-        );
         assert_eq!(stmts.len(), 1);
-        println!(
-            "[parses_block_with_return_from_full_code1] stmts[0] = {:?}",
-            stmts[0]
-        );
         assert!(matches!(stmts[0], Stmt::Return(Some(_), _)));
-        println!("[parses_block_with_return_from_full_code1] Block {{ Return(x) }}  ✓");
     }
 
-    /// break sem ponto-e-vírgula deve gerar erro sintático.
     #[test]
     fn rejects_break_without_semicolon() {
         let tokens = vec![tk(TokenKind::Break, 1), eof(6)];
 
         let mut parser = Parser::new(tokens);
-        let result = parser.parse_stmt();
-        println!("[rejects_break_without_semicolon] resultado: {result:?}");
-        assert!(result.is_err());
-        println!("[rejects_break_without_semicolon] erro esperado por ';' ausente após break  ✓");
+        assert!(parser.parse_stmt().is_err());
     }
 
-    /// continue sem ponto-e-vírgula deve gerar erro sintático.
     #[test]
     fn rejects_continue_without_semicolon() {
         let tokens = vec![tk(TokenKind::Continue, 1), eof(9)];
 
         let mut parser = Parser::new(tokens);
-        let result = parser.parse_stmt();
-        println!("[rejects_continue_without_semicolon] resultado: {result:?}");
-        assert!(result.is_err());
-        println!(
-            "[rejects_continue_without_semicolon] erro esperado por ';' ausente após continue  ✓"
-        );
+        assert!(parser.parse_stmt().is_err());
     }
 
-    /// Bloco sem fechar `}` deve gerar erro sintático.
     #[test]
     fn rejects_unclosed_block() {
         let tokens = vec![
@@ -451,15 +351,11 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let result = parser.parse_stmt();
-        println!("[rejects_unclosed_block] resultado: {result:?}");
-        assert!(result.is_err());
-        println!("[rejects_unclosed_block] erro esperado por '}}' ausente  ✓");
+        assert!(parser.parse_stmt().is_err());
     }
 
     #[test]
     fn parses_var_decl_with_init() {
-        // int x = 42;
         let tokens = vec![
             tk(TokenKind::Int, 1),
             ident("x", 5),
@@ -479,7 +375,6 @@ mod tests {
 
     #[test]
     fn parses_var_decl_no_init() {
-        // float y;
         let tokens = vec![
             tk(TokenKind::Float, 1),
             ident("y", 7),
@@ -496,7 +391,6 @@ mod tests {
 
     #[test]
     fn parses_expr_stmt() {
-        // x = 1;
         let tokens = vec![
             ident("x", 1),
             tk(TokenKind::Equal, 3),
@@ -517,7 +411,6 @@ mod tests {
 
     #[test]
     fn parses_const_pointer_var_decl() {
-        // const int *p = 0;
         let tokens = vec![
             tk(TokenKind::Const, 1),
             tk(TokenKind::Int, 7),
@@ -539,7 +432,6 @@ mod tests {
 
     #[test]
     fn parses_if_without_else() {
-        // if (x > 0) return x;
         let tokens = vec![
             tk(TokenKind::If, 1),
             tk(TokenKind::LeftParen, 4),
@@ -566,7 +458,6 @@ mod tests {
 
     #[test]
     fn parses_if_with_else() {
-        // if (x) return 1; else return 0;
         let tokens = vec![
             tk(TokenKind::If, 1),
             tk(TokenKind::LeftParen, 4),
@@ -595,7 +486,6 @@ mod tests {
 
     #[test]
     fn parses_if_else_if_chain() {
-        // if (a) return 1; else if (b) return 2;
         let tokens = vec![
             tk(TokenKind::If, 1),
             tk(TokenKind::LeftParen, 4),
@@ -627,7 +517,6 @@ mod tests {
 
     #[test]
     fn parses_if_with_block() {
-        // if (x > 0) { return x; }
         let tokens = vec![
             tk(TokenKind::If, 1),
             tk(TokenKind::LeftParen, 4),
@@ -656,7 +545,6 @@ mod tests {
 
     #[test]
     fn parses_while_stmt() {
-        // while (x > 0) x = x - 1;
         let tokens = vec![
             tk(TokenKind::While, 1),
             tk(TokenKind::LeftParen, 7),
@@ -685,7 +573,6 @@ mod tests {
 
     #[test]
     fn parses_while_with_block() {
-        // while (1) { break; }
         let tokens = vec![
             tk(TokenKind::While, 1),
             tk(TokenKind::LeftParen, 7),
@@ -711,7 +598,6 @@ mod tests {
 
     #[test]
     fn parses_do_while_stmt() {
-        // do x = x + 1; while (x < 10);
         let tokens = vec![
             tk(TokenKind::Do, 1),
             ident("x", 4),
@@ -742,7 +628,6 @@ mod tests {
 
     #[test]
     fn parses_do_while_with_block() {
-        // do { break; } while (1);
         let tokens = vec![
             tk(TokenKind::Do, 1),
             tk(TokenKind::LeftBrace, 4),

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -6,7 +6,6 @@ mod tests {
     use crate::common::input::span::ByteSpan;
     use crate::lexer::tokens::token::Token;
     use crate::lexer::tokens::token_kind::TokenKind;
-    use crate::parser::rules::statements::parse_stmt;
     use crate::parser::Parser;
 
     // Helper para criar tokens compactos nos testes sem depender do scanner.
@@ -280,7 +279,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("return válido");
+        let stmt = parser.parse_stmt().expect("return válido");
         println!("[parses_return_with_value] AST: {stmt:#?}");
 
         let Stmt::Return(Some(expr), _) = stmt else {
@@ -301,7 +300,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("return vazio válido");
+        let stmt = parser.parse_stmt().expect("return vazio válido");
         println!("[parses_return_without_value] AST: {stmt:#?}");
 
         assert!(matches!(stmt, Stmt::Return(None, _)));
@@ -314,7 +313,7 @@ mod tests {
         let tokens = vec![tk(TokenKind::Break, 1), tk(TokenKind::Semicolon, 6), eof(7)];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("break válido");
+        let stmt = parser.parse_stmt().expect("break válido");
         println!("[parses_break_statement] AST: {stmt:#?}");
 
         assert!(matches!(stmt, Stmt::Break(_)));
@@ -331,7 +330,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("continue válido");
+        let stmt = parser.parse_stmt().expect("continue válido");
         println!("[parses_continue_statement] AST: {stmt:#?}");
 
         assert!(matches!(stmt, Stmt::Continue(_)));
@@ -349,7 +348,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("expr stmt válido");
+        let stmt = parser.parse_stmt().expect("expr stmt válido");
         println!("[parses_expr_stmt_postfix_inc] AST: {stmt:#?}");
 
         let Stmt::ExprStmt(expr, _) = stmt else {
@@ -370,7 +369,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("bloco vazio válido");
+        let stmt = parser.parse_stmt().expect("bloco vazio válido");
         println!("[parses_empty_block] AST: {stmt:#?}");
 
         let Stmt::Block(stmts, _) = stmt else {
@@ -396,7 +395,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("bloco com return válido");
+        let stmt = parser.parse_stmt().expect("bloco com return válido");
         println!("[parses_block_with_return_from_full_code1] AST: {stmt:#?}");
 
         let Stmt::Block(stmts, _) = stmt else {
@@ -421,7 +420,7 @@ mod tests {
         let tokens = vec![tk(TokenKind::Break, 1), eof(6)];
 
         let mut parser = Parser::new(tokens);
-        let result = parse_stmt(&mut parser);
+        let result = parser.parse_stmt();
         println!("[rejects_break_without_semicolon] resultado: {result:?}");
         assert!(result.is_err());
         println!("[rejects_break_without_semicolon] erro esperado por ';' ausente após break  ✓");
@@ -433,7 +432,7 @@ mod tests {
         let tokens = vec![tk(TokenKind::Continue, 1), eof(9)];
 
         let mut parser = Parser::new(tokens);
-        let result = parse_stmt(&mut parser);
+        let result = parser.parse_stmt();
         println!("[rejects_continue_without_semicolon] resultado: {result:?}");
         assert!(result.is_err());
         println!(
@@ -452,7 +451,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let result = parse_stmt(&mut parser);
+        let result = parser.parse_stmt();
         println!("[rejects_unclosed_block] resultado: {result:?}");
         assert!(result.is_err());
         println!("[rejects_unclosed_block] erro esperado por '}}' ausente  ✓");
@@ -554,7 +553,7 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("if válido");
+        let stmt = parser.parse_stmt().expect("if válido");
         let Stmt::If(cond, then_branch, None, _) = stmt else {
             panic!("esperava Stmt::If sem else");
         };
@@ -583,7 +582,7 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("if-else válido");
+        let stmt = parser.parse_stmt().expect("if-else válido");
         let Stmt::If(cond, _, Some(else_branch), _) = stmt else {
             panic!("esperava Stmt::If com else");
         };
@@ -616,7 +615,7 @@ mod tests {
             eof(39),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("if-else-if válido");
+        let stmt = parser.parse_stmt().expect("if-else-if válido");
         let Stmt::If(_, _, Some(else_branch), _) = stmt else {
             panic!("esperava Stmt::If com else");
         };
@@ -644,7 +643,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("if com bloco válido");
+        let stmt = parser.parse_stmt().expect("if com bloco válido");
         let Stmt::If(cond, then_branch, None, _) = stmt else {
             panic!("esperava Stmt::If sem else");
         };
@@ -674,7 +673,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("while válido");
+        let stmt = parser.parse_stmt().expect("while válido");
         let Stmt::While(cond, body, _) = stmt else {
             panic!("esperava Stmt::While");
         };
@@ -699,7 +698,7 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("while com bloco válido");
+        let stmt = parser.parse_stmt().expect("while com bloco válido");
         let Stmt::While(cond, body, _) = stmt else {
             panic!("esperava Stmt::While");
         };
@@ -731,7 +730,7 @@ mod tests {
             eof(30),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("do-while válido");
+        let stmt = parser.parse_stmt().expect("do-while válido");
         let Stmt::DoWhile(body, cond, _) = stmt else {
             panic!("esperava Stmt::DoWhile");
         };
@@ -758,7 +757,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parse_stmt(&mut parser).expect("do-while com bloco válido");
+        let stmt = parser.parse_stmt().expect("do-while com bloco válido");
         let Stmt::DoWhile(body, cond, _) = stmt else {
             panic!("esperava Stmt::DoWhile");
         };


### PR DESCRIPTION
## Desc
Implementa parsing das construções de controle de fluxo `if`, `while` e `do-while` no parser. O nó AST `Stmt::DoWhile` foi adicionado (os demais já existiam).

 close #70 

## Mudanças

**AST (`src/common/ast/stmt.rs`)**
- Adicionado `Stmt::DoWhile(Box<Stmt>, Expr, Span)` e seu braço em `span()`

**Parser (`src/parser/rules/statements/basic.rs`)**
- **`parse_if`** — `if (expr) stmt [else stmt]`, suporta `else if` via recursão natural
- **`parse_while`** — `while (expr) stmt`
- **`parse_do_while`** — `do stmt while (expr);`
- Dispatcher atualizado para reconhecer `If`, `While`, `Do` e keywords de tipo (VarDecl)

**Testes (`src/tests/parser_test.rs`) — 8 testes novos**

| Teste | O que cobre |
|---|---|
| `parses_if_without_else` | `if (x > 0) return x;` |
| `parses_if_with_else` | `if (x) return 1; else return 0;` |
| `parses_if_else_if_chain` | `if (a)... else if (b)...` (recursão) |
| `parses_if_with_block` | `if (x > 0) { return x; }` (critério de aceite) |
| `parses_while_stmt` | `while (x > 0) x = x - 1;` |
| `parses_while_with_block` | `while (1) { break; }` |
| `parses_do_while_stmt` | `do x = x + 1; while (x < 10);` |
| `parses_do_while_with_block` | `do { break; } while (1);` |

## Critérios de aceite
- [x] `parse_if`, `parse_while`, `parse_do_while` implementadas seguindo a gramática do C
- [x] Dispatcher de `parse_stmt` reconhece os tipos e encaminha corretamente
- [x] `if(x > 0) { return x; }` parseado sem erro, produzindo `Stmt::If` correto
- [x] Testes unitários cobrindo os casos acima (80/80 passam)