### PR TITLE
feat(parser): implementa parse_for e parse_switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cargo test
 
 ```bash
 cargo test lexical      # testes do scanner/lexer (21 casos)
-cargo test parser       # testes do parser / AST (30 casos)
+cargo test parser       # testes do parser / AST (38 casos)
 cargo test literals     # testes de literais numéricos (4 casos)
 cargo test token        # testes de tokens individuais (2 casos)
 cargo test source       # testes de SourceFile e spans (12 casos)
@@ -79,7 +79,7 @@ cargo test -- --nocapture
 | `src/tests/lexical_test.rs`   | Scanner: operadores, palavras-chave, literais  | 21     |
 | `src/tests/source_test.rs`    | `SourceFile`, `ByteSpan`, posicionamento       | 12     |
 | `src/tests/lexer_file_test.rs`| Scanner sobre arquivos reais                   | 7      |
-| `src/tests/parser_test.rs`    | Parser / construção de AST                     | 30     |
+| `src/tests/parser_test.rs`    | Parser / construção de AST                     | 38     |
 | `src/tests/literals_test.rs`  | Literais inteiros, floats, strings             | 4      |
 | `src/tests/ast_errors.rs`     | Diagnósticos e erros de AST                    | 4      |
 | `src/tests/token_test.rs`     | `Token` e `TokenKind`                          | 2      |

--- a/src/common/ast/stmt.rs
+++ b/src/common/ast/stmt.rs
@@ -12,10 +12,9 @@ pub enum Stmt {
         Option<Expr>,
         Box<Stmt>,
         Span,
-    ),
-    Switch(Expr, Vec<SwitchCase>, Span),
     ), // For(Init, Cond, Inc, Body, Span)
     DoWhile(Expr, Box<Stmt>, Span),
+    Switch(Expr, Vec<SwitchCase>, Span),
     Break(Span),
     Continue(Span),
     ExprStmt(Expr, Span),

--- a/src/common/ast/stmt.rs
+++ b/src/common/ast/stmt.rs
@@ -12,8 +12,9 @@ pub enum Stmt {
         Option<Expr>,
         Box<Stmt>,
         Span,
-    ), // For(Init, Cond, Inc, Body, Span)
+    ),
     DoWhile(Box<Stmt>, Expr, Span),
+    Switch(Expr, Vec<SwitchCase>, Span),
     Break(Span),
     Continue(Span),
     ExprStmt(Expr, Span),
@@ -21,8 +22,20 @@ pub enum Stmt {
     VarDecl(QualifierType, String, Option<Expr>, Span),
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct SwitchCase {
+    pub label: SwitchLabel,
+    pub stmts: Vec<Stmt>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SwitchLabel {
+    Case(Expr),
+    Default,
+}
+
 impl Stmt {
-    /// Retorna o `Span` de código-fonte associado ao statement, independente de seu tipo.
     pub fn span(&self) -> Span {
         match self {
             Stmt::Block(_, s) => s.clone(),
@@ -30,6 +43,7 @@ impl Stmt {
             Stmt::While(_, _, s) => s.clone(),
             Stmt::For(_, _, _, _, s) => s.clone(),
             Stmt::DoWhile(_, _, s) => s.clone(),
+            Stmt::Switch(_, _, s) => s.clone(),
             Stmt::Break(s) => s.clone(),
             Stmt::Continue(s) => s.clone(),
             Stmt::ExprStmt(_, s) => s.clone(),

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -153,9 +153,8 @@ fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         parser.advance();
         None
     } else if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
-        Some(Box::new(crate::parser::rules::declarations::parse_var_decl(
-            parser,
-        )?))
+        let decl = crate::parser::rules::declarations::parse_var_decl(parser)?;
+        Some(Box::new(decl))
     } else {
         let expr = parser.parse_expr(0)?;
         let semi = parser
@@ -205,7 +204,9 @@ fn parse_switch(parser: &mut Parser) -> Result<Stmt, CompilerError> {
             (SwitchLabel::Case(case_expr), span)
         } else if parser.match_kind(&TokenKind::Default) {
             let default_kw = label_start;
-            let colon = parser.expect(&TokenKind::Colon, "':' após default")?.clone();
+            let colon = parser
+                .expect(&TokenKind::Colon, "':' após default")?
+                .clone();
             let span = parser.join_span(parser.span_of(&default_kw), parser.span_of(&colon));
             (SwitchLabel::Default, span)
         } else {

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -22,13 +22,6 @@ pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         TokenKind::Do => parse_do_while(parser),
         TokenKind::For => parse_for(parser),
         TokenKind::Switch => parse_switch(parser),
-        _ => {
-            if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
-                crate::parser::rules::declarations::parse_var_decl(parser)
-            } else {
-                parse_expr_stmt(parser)
-            }
-        }
         _ if declarations::starts_type(parser.peek_kind()) => declarations::parse_var_decl(parser),
         _ => parse_expr_stmt(parser),
     }
@@ -155,25 +148,8 @@ fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
     let init = if parser.check(&TokenKind::Semicolon) {
         parser.advance();
         None
-    } else if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
-        // Ao parsear uma declaração dentro do init do `for`, capture erros sintáticos
-        // e reemita-os com uma mensagem contextualizada para "init do for". Outros
-        // tipos de erro são propagados sem alteração.
-        match crate::parser::rules::declarations::parse_var_decl(parser) {
-            Ok(decl) => Some(Box::new(decl)),
-            Err(e) => match e {
-                CompilerError::Syntax(syn) => {
-                    return Err(CompilerError::Syntax(
-                        crate::common::errors::types::SyntaxError {
-                            span: syn.span,
-                            expected: "';' após init do for".to_string(),
-                            found: syn.found,
-                        },
-                    ));
-                }
-                other => return Err(other),
-            },
-        }
+    } else if declarations::starts_type(parser.peek_kind()) {
+        Some(Box::new(declarations::parse_var_decl(parser)?))
     } else {
         let expr = parser.parse_expr(0)?;
         let semi = parser

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -200,12 +200,12 @@ fn parse_switch(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         let (label, label_span) = if parser.match_kind(&TokenKind::Case) {
             let case_kw = label_start;
             let case_expr = parser.parse_expr(0)?;
-            let colon = parser.expect(&TokenKind::Colon, "':' após case")?.clone();
+            let colon = parser.expect(&TokenKind::Colon, "':' após case")?;
             let span = parser.join_span(parser.span_of(&case_kw), parser.span_of(&colon));
             (SwitchLabel::Case(case_expr), span)
         } else if parser.match_kind(&TokenKind::Default) {
             let default_kw = label_start;
-            let colon = parser.expect(&TokenKind::Colon, "':' após default")?.clone();
+            let colon = parser.expect(&TokenKind::Colon, "':' após default")?;
             let span = parser.join_span(parser.span_of(&default_kw), parser.span_of(&colon));
             (SwitchLabel::Default, span)
         } else {

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -153,8 +153,24 @@ fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         parser.advance();
         None
     } else if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
-        let decl = crate::parser::rules::declarations::parse_var_decl(parser)?;
-        Some(Box::new(decl))
+        // Ao parsear uma declaração dentro do init do `for`, capture erros sintáticos
+        // e reemita-os com uma mensagem contextualizada para "init do for". Outros
+        // tipos de erro são propagados sem alteração.
+        match crate::parser::rules::declarations::parse_var_decl(parser) {
+            Ok(decl) => Some(Box::new(decl)),
+            Err(e) => match e {
+                CompilerError::Syntax(syn) => {
+                    return Err(CompilerError::Syntax(
+                        crate::common::errors::types::SyntaxError {
+                            span: syn.span,
+                            expected: "';' após init do for".to_string(),
+                            found: syn.found,
+                        },
+                    ));
+                }
+                other => return Err(other),
+            },
+        }
     } else {
         let expr = parser.parse_expr(0)?;
         let semi = parser

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -200,12 +200,12 @@ fn parse_switch(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         let (label, label_span) = if parser.match_kind(&TokenKind::Case) {
             let case_kw = label_start;
             let case_expr = parser.parse_expr(0)?;
-            let colon = parser.expect(&TokenKind::Colon, "':' após case")?;
+            let colon = parser.expect(&TokenKind::Colon, "':' após case")?.clone();
             let span = parser.join_span(parser.span_of(&case_kw), parser.span_of(&colon));
             (SwitchLabel::Case(case_expr), span)
         } else if parser.match_kind(&TokenKind::Default) {
             let default_kw = label_start;
-            let colon = parser.expect(&TokenKind::Colon, "':' após default")?;
+            let colon = parser.expect(&TokenKind::Colon, "':' após default")?.clone();
             let span = parser.join_span(parser.span_of(&default_kw), parser.span_of(&colon));
             (SwitchLabel::Default, span)
         } else {

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -1,4 +1,4 @@
-use crate::common::ast::stmt::Stmt;
+use crate::common::ast::stmt::{Stmt, SwitchCase, SwitchLabel};
 use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
@@ -7,7 +7,7 @@ use crate::parser::parser::Parser;
 ///
 /// Reconhece:
 ///   `{` → bloco, `return` → return, `break` → break, `continue` → continue,
-///   `if` → if, `while` → while, `do` → do-while,
+///   `if` → if, `while` → while, `do` → do-while, `for` → for, `switch` → switch,
 ///   keywords de tipo → declaração de variável,
 ///   qualquer outra coisa → statement de expressão.
 pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
@@ -19,6 +19,8 @@ pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         TokenKind::If => parse_if(parser),
         TokenKind::While => parse_while(parser),
         TokenKind::Do => parse_do_while(parser),
+        TokenKind::For => parse_for(parser),
+        TokenKind::Switch => parse_switch(parser),
         _ => {
             if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
                 crate::parser::rules::declarations::parse_var_decl(parser)
@@ -140,6 +142,96 @@ fn parse_do_while(parser: &mut Parser) -> Result<Stmt, CompilerError> {
 
     let span = parser.join_span(parser.span_of(&kw), parser.span_of(&semi));
     Ok(Stmt::DoWhile(Box::new(body), cond, span))
+}
+
+/// Parseia `for ( (decl | expr_stmt | ;) expr? ; expr? ) stmt`.
+fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
+    let kw = parser.expect(&TokenKind::For, "'for'")?.clone();
+    parser.expect(&TokenKind::LeftParen, "'(' após for")?;
+
+    let init = if parser.check(&TokenKind::Semicolon) {
+        parser.advance();
+        None
+    } else if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
+        let decl = crate::parser::rules::declarations::parse_var_decl(parser)?;
+        Some(Box::new(decl))
+    } else {
+        let expr = parser.parse_expr(0)?;
+        let semi = parser
+            .expect(&TokenKind::Semicolon, "';' após init do for")?
+            .clone();
+        let span = parser.join_span(expr.span(), parser.span_of(&semi));
+        Some(Box::new(Stmt::ExprStmt(expr, span)))
+    };
+
+    let cond = if parser.check(&TokenKind::Semicolon) {
+        None
+    } else {
+        Some(parser.parse_expr(0)?)
+    };
+    parser.expect(&TokenKind::Semicolon, "';' após condição do for")?;
+
+    let inc = if parser.check(&TokenKind::RightParen) {
+        None
+    } else {
+        Some(parser.parse_expr(0)?)
+    };
+    parser.expect(&TokenKind::RightParen, "')' após cabeçalho do for")?;
+
+    let body = parse_stmt(parser)?;
+
+    let span = parser.join_span(parser.span_of(&kw), body.span());
+    Ok(Stmt::For(init, cond, inc, Box::new(body), span))
+}
+
+/// Parseia `switch (expr) { (case expr : stmt* | default : stmt*)* }`.
+fn parse_switch(parser: &mut Parser) -> Result<Stmt, CompilerError> {
+    let kw = parser.expect(&TokenKind::Switch, "'switch'")?.clone();
+    parser.expect(&TokenKind::LeftParen, "'(' após switch")?;
+    let expr = parser.parse_expr(0)?;
+    parser.expect(&TokenKind::RightParen, "')' após expressão do switch")?;
+
+    parser.expect(&TokenKind::LeftBrace, "'{' após switch")?;
+
+    let mut cases = Vec::new();
+    while !parser.check(&TokenKind::RightBrace) && !parser.is_at_end() {
+        let label = if parser.match_kind(&TokenKind::Case) {
+            let case_expr = parser.parse_expr(0)?;
+            parser.expect(&TokenKind::Colon, "':' após case")?;
+            SwitchLabel::Case(case_expr)
+        } else {
+            parser.expect(&TokenKind::Default, "'default'")?;
+            parser.expect(&TokenKind::Colon, "':' após default")?;
+            SwitchLabel::Default
+        };
+
+        let label_span_start = parser.peek().clone();
+
+        let mut stmts = Vec::new();
+        while !matches!(
+            parser.peek_kind(),
+            TokenKind::Case | TokenKind::Default | TokenKind::RightBrace | TokenKind::Eof
+        ) {
+            stmts.push(parse_stmt(parser)?);
+        }
+
+        let span = if stmts.is_empty() {
+            parser.span_of(&label_span_start)
+        } else {
+            let first = stmts.first().unwrap().span();
+            let last = stmts.last().unwrap().span();
+            parser.join_span(first, last)
+        };
+
+        cases.push(SwitchCase { label, stmts, span });
+    }
+
+    let rbrace = parser
+        .expect(&TokenKind::RightBrace, "'}' para fechar switch")?
+        .clone();
+
+    let span = parser.join_span(parser.span_of(&kw), parser.span_of(&rbrace));
+    Ok(Stmt::Switch(expr, cases, span))
 }
 
 /// Parseia qualquer expressão seguida de `;`.

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -153,8 +153,9 @@ fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         parser.advance();
         None
     } else if crate::parser::rules::declarations::starts_type(parser.peek_kind()) {
-        let decl = crate::parser::rules::declarations::parse_var_decl(parser)?;
-        Some(Box::new(decl))
+        Some(Box::new(crate::parser::rules::declarations::parse_var_decl(
+            parser,
+        )?))
     } else {
         let expr = parser.parse_expr(0)?;
         let semi = parser
@@ -195,17 +196,26 @@ fn parse_switch(parser: &mut Parser) -> Result<Stmt, CompilerError> {
 
     let mut cases = Vec::new();
     while !parser.check(&TokenKind::RightBrace) && !parser.is_at_end() {
-        let label = if parser.match_kind(&TokenKind::Case) {
+        let label_start = parser.peek().clone();
+        let (label, label_span) = if parser.match_kind(&TokenKind::Case) {
+            let case_kw = label_start;
             let case_expr = parser.parse_expr(0)?;
-            parser.expect(&TokenKind::Colon, "':' após case")?;
-            SwitchLabel::Case(case_expr)
+            let colon = parser.expect(&TokenKind::Colon, "':' após case")?.clone();
+            let span = parser.join_span(parser.span_of(&case_kw), parser.span_of(&colon));
+            (SwitchLabel::Case(case_expr), span)
+        } else if parser.match_kind(&TokenKind::Default) {
+            let default_kw = label_start;
+            let colon = parser.expect(&TokenKind::Colon, "':' após default")?.clone();
+            let span = parser.join_span(parser.span_of(&default_kw), parser.span_of(&colon));
+            (SwitchLabel::Default, span)
         } else {
-            parser.expect(&TokenKind::Default, "'default'")?;
-            parser.expect(&TokenKind::Colon, "':' após default")?;
-            SwitchLabel::Default
+            let found = parser.peek().clone();
+            return Err(parser.syntax_error(
+                &found,
+                "'case' ou 'default'",
+                &format!("{:?}", found.kind),
+            ));
         };
-
-        let label_span_start = parser.peek().clone();
 
         let mut stmts = Vec::new();
         while !matches!(
@@ -216,11 +226,10 @@ fn parse_switch(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         }
 
         let span = if stmts.is_empty() {
-            parser.span_of(&label_span_start)
+            label_span
         } else {
-            let first = stmts.first().unwrap().span();
             let last = stmts.last().unwrap().span();
-            parser.join_span(first, last)
+            parser.join_span(label_span, last)
         };
 
         cases.push(SwitchCase { label, stmts, span });

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -223,9 +223,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("return válido");
-
-        let Stmt::Return(Some(expr), _) = stmt else {
+        let Stmt::Return(Some(expr), _) = parser.parse_stmt().expect("return válido") else {
             panic!("esperava Stmt::Return com valor");
         };
         assert!(matches!(expr, Expr::Ident(ref s, _) if s == "x"));
@@ -240,9 +238,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("return vazio válido");
-
-        assert!(matches!(stmt, Stmt::Return(None, _)));
+        assert!(matches!(parser.parse_stmt().expect("return vazio válido"), Stmt::Return(None, _)));
     }
 
     #[test]
@@ -250,9 +246,7 @@ mod tests {
         let tokens = vec![tk(TokenKind::Break, 1), tk(TokenKind::Semicolon, 6), eof(7)];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("break válido");
-
-        assert!(matches!(stmt, Stmt::Break(_)));
+        assert!(matches!(parser.parse_stmt().expect("break válido"), Stmt::Break(_)));
     }
 
     #[test]
@@ -264,9 +258,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("continue válido");
-
-        assert!(matches!(stmt, Stmt::Continue(_)));
+        assert!(matches!(parser.parse_stmt().expect("continue válido"), Stmt::Continue(_)));
     }
 
     #[test]
@@ -279,9 +271,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("expr stmt válido");
-
-        let Stmt::ExprStmt(expr, _) = stmt else {
+        let Stmt::ExprStmt(expr, _) = parser.parse_stmt().expect("expr stmt válido") else {
             panic!("esperava ExprStmt");
         };
         assert!(matches!(expr, Expr::Postfix(PostfixOp::Inc, _, _)));
@@ -296,9 +286,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("bloco vazio válido");
-
-        let Stmt::Block(stmts, _) = stmt else {
+        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco vazio válido") else {
             panic!("esperava Block");
         };
         assert!(stmts.is_empty());
@@ -316,9 +304,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("bloco com return válido");
-
-        let Stmt::Block(stmts, _) = stmt else {
+        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco com return válido") else {
             panic!("esperava Block");
         };
         assert_eq!(stmts.len(), 1);
@@ -364,8 +350,7 @@ mod tests {
             tk(TokenKind::Semicolon, 11),
             eof(12),
         ];
-        let stmt = Parser::new(tokens).parse_stmt().expect("decl válida");
-        let Stmt::VarDecl(qty, name, Some(init), _) = stmt else {
+        let Stmt::VarDecl(qty, name, Some(init), _) = Parser::new(tokens).parse_stmt().expect("decl válida") else {
             panic!("esperava VarDecl com init");
         };
         assert!(matches!(qty.ty, Type::Int));
@@ -381,8 +366,7 @@ mod tests {
             tk(TokenKind::Semicolon, 8),
             eof(9),
         ];
-        let stmt = Parser::new(tokens).parse_stmt().expect("decl válida");
-        let Stmt::VarDecl(qty, name, None, _) = stmt else {
+        let Stmt::VarDecl(qty, name, None, _) = Parser::new(tokens).parse_stmt().expect("decl válida") else {
             panic!("esperava VarDecl sem init");
         };
         assert!(matches!(qty.ty, Type::Float));
@@ -398,8 +382,7 @@ mod tests {
             tk(TokenKind::Semicolon, 6),
             eof(7),
         ];
-        let stmt = Parser::new(tokens).parse_stmt().expect("expr stmt válido");
-        let Stmt::ExprStmt(expr, _) = stmt else {
+        let Stmt::ExprStmt(expr, _) = Parser::new(tokens).parse_stmt().expect("expr stmt válido") else {
             panic!("esperava ExprStmt");
         };
         let Expr::Assign(lhs, rhs, _) = expr else {
@@ -421,8 +404,7 @@ mod tests {
             tk(TokenKind::Semicolon, 17),
             eof(18),
         ];
-        let stmt = Parser::new(tokens).parse_stmt().expect("decl válida");
-        let Stmt::VarDecl(qty, name, Some(_), _) = stmt else {
+        let Stmt::VarDecl(qty, name, Some(_), _) = Parser::new(tokens).parse_stmt().expect("decl válida") else {
             panic!("esperava VarDecl");
         };
         assert!(qty.is_const);
@@ -445,8 +427,7 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("if válido");
-        let Stmt::If(cond, then_branch, None, _) = stmt else {
+        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if válido") else {
             panic!("esperava Stmt::If sem else");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -473,8 +454,7 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("if-else válido");
-        let Stmt::If(cond, _, Some(else_branch), _) = stmt else {
+        let Stmt::If(cond, _, Some(else_branch), _) = parser.parse_stmt().expect("if-else válido") else {
             panic!("esperava Stmt::If com else");
         };
         assert!(matches!(cond, Expr::Ident(name, _) if name == "x"));
@@ -505,8 +485,7 @@ mod tests {
             eof(39),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("if-else-if válido");
-        let Stmt::If(_, _, Some(else_branch), _) = stmt else {
+        let Stmt::If(_, _, Some(else_branch), _) = parser.parse_stmt().expect("if-else-if válido") else {
             panic!("esperava Stmt::If com else");
         };
         let Stmt::If(inner_cond, _, None, _) = *else_branch else {
@@ -532,8 +511,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("if com bloco válido");
-        let Stmt::If(cond, then_branch, None, _) = stmt else {
+        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if com bloco válido") else {
             panic!("esperava Stmt::If sem else");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -561,8 +539,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("while válido");
-        let Stmt::While(cond, body, _) = stmt else {
+        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while válido") else {
             panic!("esperava Stmt::While");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -585,8 +562,7 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("while com bloco válido");
-        let Stmt::While(cond, body, _) = stmt else {
+        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while com bloco válido") else {
             panic!("esperava Stmt::While");
         };
         assert!(matches!(cond, Expr::Literal(Literal::Int(1), _)));
@@ -616,8 +592,7 @@ mod tests {
             eof(30),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("do-while válido");
-        let Stmt::DoWhile(body, cond, _) = stmt else {
+        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while válido") else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
@@ -642,8 +617,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("do-while com bloco válido");
-        let Stmt::DoWhile(body, cond, _) = stmt else {
+        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while com bloco válido") else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::Block(stmts, _) = *body else {
@@ -676,8 +650,7 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("for válido");
-        let Stmt::For(init, cond, inc, body, _) = stmt else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for válido") else {
             panic!("esperava Stmt::For");
         };
         let init_stmt = init.expect("esperava init");
@@ -717,8 +690,7 @@ mod tests {
             eof(28),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("for com expr init válido");
-        let Stmt::For(init, cond, inc, body, _) = stmt else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for com expr init válido") else {
             panic!("esperava Stmt::For");
         };
         let init_stmt = init.expect("esperava init");
@@ -752,8 +724,7 @@ mod tests {
             eof(23),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("for com init vazio válido");
-        let Stmt::For(init, cond, inc, _, _) = stmt else {
+        let Stmt::For(init, cond, inc, _, _) = parser.parse_stmt().expect("for com init vazio válido") else {
             panic!("esperava Stmt::For");
         };
         assert!(init.is_none());
@@ -775,8 +746,7 @@ mod tests {
             eof(12),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("for (;;) válido");
-        let Stmt::For(init, cond, inc, body, _) = stmt else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for (;;) válido") else {
             panic!("esperava Stmt::For");
         };
         assert!(init.is_none());
@@ -809,8 +779,7 @@ mod tests {
             eof(28),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("for sem inc válido");
-        let Stmt::For(_, _, inc, _, _) = stmt else {
+        let Stmt::For(_, _, inc, _, _) = parser.parse_stmt().expect("for sem inc válido") else {
             panic!("esperava Stmt::For");
         };
         assert!(inc.is_none());
@@ -838,8 +807,7 @@ mod tests {
             eof(46),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("switch válido");
-        let Stmt::Switch(expr, cases, _) = stmt else {
+        let Stmt::Switch(expr, cases, _) = parser.parse_stmt().expect("switch válido") else {
             panic!("esperava Stmt::Switch");
         };
         assert!(matches!(expr, Expr::Ident(name, _) if name == "x"));
@@ -885,8 +853,7 @@ mod tests {
             eof(68),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("switch com múltiplos cases válido");
-        let Stmt::Switch(_, cases, _) = stmt else {
+        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch com múltiplos cases válido") else {
             panic!("esperava Stmt::Switch");
         };
         assert_eq!(cases.len(), 3);
@@ -914,8 +881,7 @@ mod tests {
             eof(31),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("switch default-only válido");
-        let Stmt::Switch(_, cases, _) = stmt else {
+        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch default-only válido") else {
             panic!("esperava Stmt::Switch");
         };
         assert_eq!(cases.len(), 1);

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -160,8 +160,7 @@ mod tests {
             },
             inner,
             _,
-        ) = expr
-        else {
+        ) = expr else {
             panic!("esperava cast no topo da árvore");
         };
 

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -613,8 +613,7 @@ mod tests {
             eof(30),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("do-while válido");
-        let Stmt::DoWhile(cond, body, _) = stmt else {
+        let Stmt::DoWhile(cond, body, _) = parser.parse_stmt().expect("do-while válido") else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
@@ -639,8 +638,8 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let stmt = parser.parse_stmt().expect("do-while com bloco válido");
-        let Stmt::DoWhile(cond, body, _) = stmt else {
+        let Stmt::DoWhile(cond, body, _) = parser.parse_stmt().expect("do-while com bloco válido")
+        else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::Block(stmts, _) = *body else {
@@ -926,8 +925,10 @@ mod tests {
         assert!(matches!(&cases[0].label, SwitchLabel::Default));
         assert_eq!(cases[0].stmts.len(), 1);
         assert!(matches!(&cases[0].stmts[0], Stmt::Break(_)));
+    }
+
+    #[test]
     fn rejects_if_missing_right_paren() {
-        // if (x { return; }  — falta ')'
         let tokens = vec![
             tk(TokenKind::If, 1),
             tk(TokenKind::LeftParen, 4),
@@ -940,7 +941,6 @@ mod tests {
 
     #[test]
     fn rejects_while_missing_left_paren() {
-        // while x > 0)  — falta '('
         let tokens = vec![
             tk(TokenKind::While, 1),
             ident("x", 7),
@@ -954,7 +954,6 @@ mod tests {
 
     #[test]
     fn rejects_do_while_missing_semicolon() {
-        // do { } while (1)  — falta ';'
         let tokens = vec![
             tk(TokenKind::Do, 1),
             tk(TokenKind::LeftBrace, 4),
@@ -964,6 +963,45 @@ mod tests {
             int(1, 14),
             tk(TokenKind::RightParen, 15),
             eof(16),
+        ];
+        assert!(Parser::new(tokens).parse_stmt().is_err());
+    }
+
+    #[test]
+    fn rejects_for_missing_right_paren() {
+        let tokens = vec![
+            tk(TokenKind::For, 1),
+            tk(TokenKind::LeftParen, 5),
+            tk(TokenKind::Semicolon, 6),
+            tk(TokenKind::Semicolon, 7),
+            eof(8),
+        ];
+        assert!(Parser::new(tokens).parse_stmt().is_err());
+    }
+
+    #[test]
+    fn rejects_switch_missing_left_paren() {
+        let tokens = vec![
+            tk(TokenKind::Switch, 1),
+            ident("x", 8),
+            tk(TokenKind::RightParen, 9),
+            eof(10),
+        ];
+        assert!(Parser::new(tokens).parse_stmt().is_err());
+    }
+
+    #[test]
+    fn rejects_switch_case_missing_colon() {
+        let tokens = vec![
+            tk(TokenKind::Switch, 1),
+            tk(TokenKind::LeftParen, 8),
+            ident("x", 9),
+            tk(TokenKind::RightParen, 10),
+            tk(TokenKind::LeftBrace, 12),
+            tk(TokenKind::Case, 14),
+            int(1, 19),
+            tk(TokenKind::Break, 21),
+            eof(26),
         ];
         assert!(Parser::new(tokens).parse_stmt().is_err());
     }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::common::ast::ast::{QualifierType, Type};
     use crate::common::ast::expr::{BinOp, Expr, Literal, PostfixOp, PrefixOp};
-    use crate::common::ast::stmt::Stmt;
+    use crate::common::ast::stmt::{Stmt, SwitchLabel};
     use crate::common::input::span::ByteSpan;
     use crate::lexer::tokens::token::Token;
     use crate::lexer::tokens::token_kind::TokenKind;
@@ -651,5 +651,276 @@ mod tests {
         };
         assert!(matches!(&stmts[0], Stmt::Break(_)));
         assert!(matches!(cond, Expr::Literal(Literal::Int(1), _)));
+    }
+
+    #[test]
+    fn parses_for_with_var_decl_init() {
+        // for (int i = 0; i < 10; i++) {}
+        let tokens = vec![
+            tk(TokenKind::For, 1),
+            tk(TokenKind::LeftParen, 5),
+            tk(TokenKind::Int, 6),
+            ident("i", 10),
+            tk(TokenKind::Equal, 12),
+            int(0, 14),
+            tk(TokenKind::Semicolon, 15),
+            ident("i", 17),
+            tk(TokenKind::Less, 19),
+            int(10, 21),
+            tk(TokenKind::Semicolon, 23),
+            ident("i", 25),
+            tk(TokenKind::PlusPlus, 26),
+            tk(TokenKind::RightParen, 28),
+            tk(TokenKind::LeftBrace, 30),
+            tk(TokenKind::RightBrace, 31),
+            eof(32),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("for válido");
+        let Stmt::For(init, cond, inc, body, _) = stmt else {
+            panic!("esperava Stmt::For");
+        };
+        let init_stmt = init.expect("esperava init");
+        let Stmt::VarDecl(qty, name, Some(val), _) = *init_stmt else {
+            panic!("esperava VarDecl no init");
+        };
+        assert!(matches!(qty.ty, Type::Int));
+        assert_eq!(name, "i");
+        assert!(matches!(val, Expr::Literal(Literal::Int(0), _)));
+        assert!(matches!(cond, Some(Expr::Binary(_, BinOp::Less, _, _))));
+        assert!(matches!(inc, Some(Expr::Postfix(PostfixOp::Inc, _, _))));
+        let Stmt::Block(stmts, _) = *body else {
+            panic!("esperava bloco no corpo do for");
+        };
+        assert!(stmts.is_empty());
+    }
+
+    #[test]
+    fn parses_for_with_expr_init() {
+        // for (i = 0; i < 10; i++) {}
+        let tokens = vec![
+            tk(TokenKind::For, 1),
+            tk(TokenKind::LeftParen, 5),
+            ident("i", 6),
+            tk(TokenKind::Equal, 8),
+            int(0, 10),
+            tk(TokenKind::Semicolon, 11),
+            ident("i", 13),
+            tk(TokenKind::Less, 15),
+            int(10, 17),
+            tk(TokenKind::Semicolon, 19),
+            ident("i", 21),
+            tk(TokenKind::PlusPlus, 22),
+            tk(TokenKind::RightParen, 24),
+            tk(TokenKind::LeftBrace, 26),
+            tk(TokenKind::RightBrace, 27),
+            eof(28),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("for com expr init válido");
+        let Stmt::For(init, cond, inc, body, _) = stmt else {
+            panic!("esperava Stmt::For");
+        };
+        let init_stmt = init.expect("esperava init");
+        let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *init_stmt else {
+            panic!("esperava ExprStmt no init");
+        };
+        assert!(matches!(cond, Some(Expr::Binary(_, BinOp::Less, _, _))));
+        assert!(matches!(inc, Some(Expr::Postfix(PostfixOp::Inc, _, _))));
+        let Stmt::Block(stmts, _) = *body else {
+            panic!("esperava bloco no corpo do for");
+        };
+        assert!(stmts.is_empty());
+    }
+
+    #[test]
+    fn parses_for_empty_init() {
+        // for (; i < 10; i++) {}
+        let tokens = vec![
+            tk(TokenKind::For, 1),
+            tk(TokenKind::LeftParen, 5),
+            tk(TokenKind::Semicolon, 6),
+            ident("i", 8),
+            tk(TokenKind::Less, 10),
+            int(10, 12),
+            tk(TokenKind::Semicolon, 14),
+            ident("i", 16),
+            tk(TokenKind::PlusPlus, 17),
+            tk(TokenKind::RightParen, 19),
+            tk(TokenKind::LeftBrace, 21),
+            tk(TokenKind::RightBrace, 22),
+            eof(23),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("for com init vazio válido");
+        let Stmt::For(init, cond, inc, _, _) = stmt else {
+            panic!("esperava Stmt::For");
+        };
+        assert!(init.is_none());
+        assert!(matches!(cond, Some(Expr::Binary(_, BinOp::Less, _, _))));
+        assert!(matches!(inc, Some(Expr::Postfix(PostfixOp::Inc, _, _))));
+    }
+
+    #[test]
+    fn parses_for_no_cond_no_inc() {
+        // for (;;) {}
+        let tokens = vec![
+            tk(TokenKind::For, 1),
+            tk(TokenKind::LeftParen, 5),
+            tk(TokenKind::Semicolon, 6),
+            tk(TokenKind::Semicolon, 7),
+            tk(TokenKind::RightParen, 8),
+            tk(TokenKind::LeftBrace, 10),
+            tk(TokenKind::RightBrace, 11),
+            eof(12),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("for (;;) válido");
+        let Stmt::For(init, cond, inc, body, _) = stmt else {
+            panic!("esperava Stmt::For");
+        };
+        assert!(init.is_none());
+        assert!(cond.is_none());
+        assert!(inc.is_none());
+        let Stmt::Block(stmts, _) = *body else {
+            panic!("esperava bloco");
+        };
+        assert!(stmts.is_empty());
+    }
+
+    #[test]
+    fn parses_for_no_inc() {
+        // for (int i = 0; i < 10;) {}
+        let tokens = vec![
+            tk(TokenKind::For, 1),
+            tk(TokenKind::LeftParen, 5),
+            tk(TokenKind::Int, 6),
+            ident("i", 10),
+            tk(TokenKind::Equal, 12),
+            int(0, 14),
+            tk(TokenKind::Semicolon, 15),
+            ident("i", 17),
+            tk(TokenKind::Less, 19),
+            int(10, 21),
+            tk(TokenKind::Semicolon, 23),
+            tk(TokenKind::RightParen, 24),
+            tk(TokenKind::LeftBrace, 26),
+            tk(TokenKind::RightBrace, 27),
+            eof(28),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("for sem inc válido");
+        let Stmt::For(_, _, inc, _, _) = stmt else {
+            panic!("esperava Stmt::For");
+        };
+        assert!(inc.is_none());
+    }
+
+    #[test]
+    fn parses_switch_with_case_and_default() {
+        // switch (x) { case 1: break; default: break; }
+        let tokens = vec![
+            tk(TokenKind::Switch, 1),
+            tk(TokenKind::LeftParen, 8),
+            ident("x", 9),
+            tk(TokenKind::RightParen, 10),
+            tk(TokenKind::LeftBrace, 12),
+            tk(TokenKind::Case, 14),
+            int(1, 19),
+            tk(TokenKind::Colon, 20),
+            tk(TokenKind::Break, 22),
+            tk(TokenKind::Semicolon, 27),
+            tk(TokenKind::Default, 29),
+            tk(TokenKind::Colon, 36),
+            tk(TokenKind::Break, 38),
+            tk(TokenKind::Semicolon, 43),
+            tk(TokenKind::RightBrace, 45),
+            eof(46),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("switch válido");
+        let Stmt::Switch(expr, cases, _) = stmt else {
+            panic!("esperava Stmt::Switch");
+        };
+        assert!(matches!(expr, Expr::Ident(name, _) if name == "x"));
+        assert_eq!(cases.len(), 2);
+
+        assert!(matches!(&cases[0].label, SwitchLabel::Case(Expr::Literal(Literal::Int(1), _))));
+        assert_eq!(cases[0].stmts.len(), 1);
+        assert!(matches!(&cases[0].stmts[0], Stmt::Break(_)));
+
+        assert!(matches!(&cases[1].label, SwitchLabel::Default));
+        assert_eq!(cases[1].stmts.len(), 1);
+        assert!(matches!(&cases[1].stmts[0], Stmt::Break(_)));
+    }
+
+    #[test]
+    fn parses_switch_multiple_cases() {
+        // switch (x) { case 1: x = 2; break; case 2: break; default: break; }
+        let tokens = vec![
+            tk(TokenKind::Switch, 1),
+            tk(TokenKind::LeftParen, 8),
+            ident("x", 9),
+            tk(TokenKind::RightParen, 10),
+            tk(TokenKind::LeftBrace, 12),
+            tk(TokenKind::Case, 14),
+            int(1, 19),
+            tk(TokenKind::Colon, 20),
+            ident("x", 22),
+            tk(TokenKind::Equal, 24),
+            int(2, 26),
+            tk(TokenKind::Semicolon, 27),
+            tk(TokenKind::Break, 29),
+            tk(TokenKind::Semicolon, 34),
+            tk(TokenKind::Case, 36),
+            int(2, 41),
+            tk(TokenKind::Colon, 42),
+            tk(TokenKind::Break, 44),
+            tk(TokenKind::Semicolon, 49),
+            tk(TokenKind::Default, 51),
+            tk(TokenKind::Colon, 58),
+            tk(TokenKind::Break, 60),
+            tk(TokenKind::Semicolon, 65),
+            tk(TokenKind::RightBrace, 67),
+            eof(68),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("switch com múltiplos cases válido");
+        let Stmt::Switch(_, cases, _) = stmt else {
+            panic!("esperava Stmt::Switch");
+        };
+        assert_eq!(cases.len(), 3);
+        assert_eq!(cases[0].stmts.len(), 2);
+        assert!(matches!(&cases[0].stmts[0], Stmt::ExprStmt(Expr::Assign(_, _, _), _)));
+        assert!(matches!(&cases[0].stmts[1], Stmt::Break(_)));
+        assert_eq!(cases[1].stmts.len(), 1);
+        assert_eq!(cases[2].stmts.len(), 1);
+    }
+
+    #[test]
+    fn parses_switch_default_only() {
+        // switch (x) { default: break; }
+        let tokens = vec![
+            tk(TokenKind::Switch, 1),
+            tk(TokenKind::LeftParen, 8),
+            ident("x", 9),
+            tk(TokenKind::RightParen, 10),
+            tk(TokenKind::LeftBrace, 12),
+            tk(TokenKind::Default, 14),
+            tk(TokenKind::Colon, 21),
+            tk(TokenKind::Break, 23),
+            tk(TokenKind::Semicolon, 28),
+            tk(TokenKind::RightBrace, 30),
+            eof(31),
+        ];
+        let mut parser = Parser::new(tokens);
+        let stmt = parser.parse_stmt().expect("switch default-only válido");
+        let Stmt::Switch(_, cases, _) = stmt else {
+            panic!("esperava Stmt::Switch");
+        };
+        assert_eq!(cases.len(), 1);
+        assert!(matches!(&cases[0].label, SwitchLabel::Default));
+        assert_eq!(cases[0].stmts.len(), 1);
+        assert!(matches!(&cases[0].stmts[0], Stmt::Break(_)));
     }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -160,7 +160,8 @@ mod tests {
             },
             inner,
             _,
-        ) = expr else {
+        ) = expr
+        else {
             panic!("esperava cast no topo da árvore");
         };
 
@@ -222,8 +223,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::Return(Some(expr), _) = parser.parse_stmt().expect("return válido")
-        else {
+        let Stmt::Return(Some(expr), _) = parser.parse_stmt().expect("return válido") else {
             panic!("esperava Stmt::Return com valor");
         };
         assert!(matches!(expr, Expr::Ident(ref s, _) if s == "x"));
@@ -238,7 +238,10 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        assert!(matches!(parser.parse_stmt().expect("return vazio válido"), Stmt::Return(None, _)));
+        assert!(matches!(
+            parser.parse_stmt().expect("return vazio válido"),
+            Stmt::Return(None, _)
+        ));
     }
 
     #[test]
@@ -246,7 +249,10 @@ mod tests {
         let tokens = vec![tk(TokenKind::Break, 1), tk(TokenKind::Semicolon, 6), eof(7)];
 
         let mut parser = Parser::new(tokens);
-        assert!(matches!(parser.parse_stmt().expect("break válido"), Stmt::Break(_)));
+        assert!(matches!(
+            parser.parse_stmt().expect("break válido"),
+            Stmt::Break(_)
+        ));
     }
 
     #[test]
@@ -258,7 +264,10 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        assert!(matches!(parser.parse_stmt().expect("continue válido"), Stmt::Continue(_)));
+        assert!(matches!(
+            parser.parse_stmt().expect("continue válido"),
+            Stmt::Continue(_)
+        ));
     }
 
     #[test]
@@ -271,8 +280,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::ExprStmt(expr, _) = parser.parse_stmt().expect("expr stmt válido")
-        else {
+        let Stmt::ExprStmt(expr, _) = parser.parse_stmt().expect("expr stmt válido") else {
             panic!("esperava ExprStmt");
         };
         assert!(matches!(expr, Expr::Postfix(PostfixOp::Inc, _, _)));
@@ -287,8 +295,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco vazio válido")
-        else {
+        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco vazio válido") else {
             panic!("esperava Block");
         };
         assert!(stmts.is_empty());
@@ -306,8 +313,7 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco com return válido")
-        else {
+        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco com return válido") else {
             panic!("esperava Block");
         };
         assert_eq!(stmts.len(), 1);
@@ -353,7 +359,8 @@ mod tests {
             tk(TokenKind::Semicolon, 11),
             eof(12),
         ];
-        let Stmt::VarDecl(qty, name, Some(init), _) = Parser::new(tokens).parse_stmt().expect("decl válida")
+        let Stmt::VarDecl(qty, name, Some(init), _) =
+            Parser::new(tokens).parse_stmt().expect("decl válida")
         else {
             panic!("esperava VarDecl com init");
         };
@@ -370,7 +377,8 @@ mod tests {
             tk(TokenKind::Semicolon, 8),
             eof(9),
         ];
-        let Stmt::VarDecl(qty, name, None, _) = Parser::new(tokens).parse_stmt().expect("decl válida")
+        let Stmt::VarDecl(qty, name, None, _) =
+            Parser::new(tokens).parse_stmt().expect("decl válida")
         else {
             panic!("esperava VarDecl sem init");
         };
@@ -410,7 +418,8 @@ mod tests {
             tk(TokenKind::Semicolon, 17),
             eof(18),
         ];
-        let Stmt::VarDecl(qty, name, Some(_), _) = Parser::new(tokens).parse_stmt().expect("decl válida")
+        let Stmt::VarDecl(qty, name, Some(_), _) =
+            Parser::new(tokens).parse_stmt().expect("decl válida")
         else {
             panic!("esperava VarDecl");
         };
@@ -434,8 +443,7 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if válido")
-        else {
+        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if válido") else {
             panic!("esperava Stmt::If sem else");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -521,7 +529,8 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if com bloco válido")
+        let Stmt::If(cond, then_branch, None, _) =
+            parser.parse_stmt().expect("if com bloco válido")
         else {
             panic!("esperava Stmt::If sem else");
         };
@@ -550,8 +559,7 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while válido")
-        else {
+        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while válido") else {
             panic!("esperava Stmt::While");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -605,8 +613,7 @@ mod tests {
             eof(30),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while válido")
-        else {
+        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while válido") else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
@@ -665,8 +672,7 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for válido")
-        else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for válido") else {
             panic!("esperava Stmt::For");
         };
         let init_stmt = init.expect("esperava init");
@@ -706,7 +712,8 @@ mod tests {
             eof(28),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for com expr init válido")
+        let Stmt::For(init, cond, inc, body, _) =
+            parser.parse_stmt().expect("for com expr init válido")
         else {
             panic!("esperava Stmt::For");
         };
@@ -741,7 +748,8 @@ mod tests {
             eof(23),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, _, _) = parser.parse_stmt().expect("for com init vazio válido")
+        let Stmt::For(init, cond, inc, _, _) =
+            parser.parse_stmt().expect("for com init vazio válido")
         else {
             panic!("esperava Stmt::For");
         };
@@ -798,8 +806,7 @@ mod tests {
             eof(28),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(_, _, inc, _, _) = parser.parse_stmt().expect("for sem inc válido")
-        else {
+        let Stmt::For(_, _, inc, _, _) = parser.parse_stmt().expect("for sem inc válido") else {
             panic!("esperava Stmt::For");
         };
         assert!(inc.is_none());
@@ -827,14 +834,16 @@ mod tests {
             eof(46),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::Switch(expr, cases, _) = parser.parse_stmt().expect("switch válido")
-        else {
+        let Stmt::Switch(expr, cases, _) = parser.parse_stmt().expect("switch válido") else {
             panic!("esperava Stmt::Switch");
         };
         assert!(matches!(expr, Expr::Ident(name, _) if name == "x"));
         assert_eq!(cases.len(), 2);
 
-        assert!(matches!(&cases[0].label, SwitchLabel::Case(Expr::Literal(Literal::Int(1), _))));
+        assert!(matches!(
+            &cases[0].label,
+            SwitchLabel::Case(Expr::Literal(Literal::Int(1), _))
+        ));
         assert_eq!(cases[0].stmts.len(), 1);
         assert!(matches!(&cases[0].stmts[0], Stmt::Break(_)));
 
@@ -874,13 +883,18 @@ mod tests {
             eof(68),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch com múltiplos cases válido")
+        let Stmt::Switch(_, cases, _) = parser
+            .parse_stmt()
+            .expect("switch com múltiplos cases válido")
         else {
             panic!("esperava Stmt::Switch");
         };
         assert_eq!(cases.len(), 3);
         assert_eq!(cases[0].stmts.len(), 2);
-        assert!(matches!(&cases[0].stmts[0], Stmt::ExprStmt(Expr::Assign(_, _, _), _)));
+        assert!(matches!(
+            &cases[0].stmts[0],
+            Stmt::ExprStmt(Expr::Assign(_, _, _), _)
+        ));
         assert!(matches!(&cases[0].stmts[1], Stmt::Break(_)));
         assert_eq!(cases[1].stmts.len(), 1);
         assert_eq!(cases[2].stmts.len(), 1);

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -222,7 +222,8 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::Return(Some(expr), _) = parser.parse_stmt().expect("return válido") else {
+        let Stmt::Return(Some(expr), _) = parser.parse_stmt().expect("return válido")
+        else {
             panic!("esperava Stmt::Return com valor");
         };
         assert!(matches!(expr, Expr::Ident(ref s, _) if s == "x"));
@@ -270,7 +271,8 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::ExprStmt(expr, _) = parser.parse_stmt().expect("expr stmt válido") else {
+        let Stmt::ExprStmt(expr, _) = parser.parse_stmt().expect("expr stmt válido")
+        else {
             panic!("esperava ExprStmt");
         };
         assert!(matches!(expr, Expr::Postfix(PostfixOp::Inc, _, _)));
@@ -285,7 +287,8 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco vazio válido") else {
+        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco vazio válido")
+        else {
             panic!("esperava Block");
         };
         assert!(stmts.is_empty());
@@ -303,7 +306,8 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco com return válido") else {
+        let Stmt::Block(stmts, _) = parser.parse_stmt().expect("bloco com return válido")
+        else {
             panic!("esperava Block");
         };
         assert_eq!(stmts.len(), 1);
@@ -349,7 +353,8 @@ mod tests {
             tk(TokenKind::Semicolon, 11),
             eof(12),
         ];
-        let Stmt::VarDecl(qty, name, Some(init), _) = Parser::new(tokens).parse_stmt().expect("decl válida") else {
+        let Stmt::VarDecl(qty, name, Some(init), _) = Parser::new(tokens).parse_stmt().expect("decl válida")
+        else {
             panic!("esperava VarDecl com init");
         };
         assert!(matches!(qty.ty, Type::Int));
@@ -365,7 +370,8 @@ mod tests {
             tk(TokenKind::Semicolon, 8),
             eof(9),
         ];
-        let Stmt::VarDecl(qty, name, None, _) = Parser::new(tokens).parse_stmt().expect("decl válida") else {
+        let Stmt::VarDecl(qty, name, None, _) = Parser::new(tokens).parse_stmt().expect("decl válida")
+        else {
             panic!("esperava VarDecl sem init");
         };
         assert!(matches!(qty.ty, Type::Float));
@@ -381,7 +387,8 @@ mod tests {
             tk(TokenKind::Semicolon, 6),
             eof(7),
         ];
-        let Stmt::ExprStmt(expr, _) = Parser::new(tokens).parse_stmt().expect("expr stmt válido") else {
+        let Stmt::ExprStmt(expr, _) = Parser::new(tokens).parse_stmt().expect("expr stmt válido")
+        else {
             panic!("esperava ExprStmt");
         };
         let Expr::Assign(lhs, rhs, _) = expr else {
@@ -403,7 +410,8 @@ mod tests {
             tk(TokenKind::Semicolon, 17),
             eof(18),
         ];
-        let Stmt::VarDecl(qty, name, Some(_), _) = Parser::new(tokens).parse_stmt().expect("decl válida") else {
+        let Stmt::VarDecl(qty, name, Some(_), _) = Parser::new(tokens).parse_stmt().expect("decl válida")
+        else {
             panic!("esperava VarDecl");
         };
         assert!(qty.is_const);
@@ -426,7 +434,8 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if válido") else {
+        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if válido")
+        else {
             panic!("esperava Stmt::If sem else");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -453,7 +462,8 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::If(cond, _, Some(else_branch), _) = parser.parse_stmt().expect("if-else válido") else {
+        let Stmt::If(cond, _, Some(else_branch), _) = parser.parse_stmt().expect("if-else válido")
+        else {
             panic!("esperava Stmt::If com else");
         };
         assert!(matches!(cond, Expr::Ident(name, _) if name == "x"));
@@ -484,7 +494,8 @@ mod tests {
             eof(39),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::If(_, _, Some(else_branch), _) = parser.parse_stmt().expect("if-else-if válido") else {
+        let Stmt::If(_, _, Some(else_branch), _) = parser.parse_stmt().expect("if-else-if válido")
+        else {
             panic!("esperava Stmt::If com else");
         };
         let Stmt::If(inner_cond, _, None, _) = *else_branch else {
@@ -510,7 +521,8 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if com bloco válido") else {
+        let Stmt::If(cond, then_branch, None, _) = parser.parse_stmt().expect("if com bloco válido")
+        else {
             panic!("esperava Stmt::If sem else");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -538,7 +550,8 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while válido") else {
+        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while válido")
+        else {
             panic!("esperava Stmt::While");
         };
         assert!(matches!(cond, Expr::Binary(_, BinOp::Greater, _, _)));
@@ -561,7 +574,8 @@ mod tests {
             eof(21),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while com bloco válido") else {
+        let Stmt::While(cond, body, _) = parser.parse_stmt().expect("while com bloco válido")
+        else {
             panic!("esperava Stmt::While");
         };
         assert!(matches!(cond, Expr::Literal(Literal::Int(1), _)));
@@ -591,7 +605,8 @@ mod tests {
             eof(30),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while válido") else {
+        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while válido")
+        else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::ExprStmt(Expr::Assign(_, _, _), _) = *body else {
@@ -616,7 +631,8 @@ mod tests {
             eof(25),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while com bloco válido") else {
+        let Stmt::DoWhile(body, cond, _) = parser.parse_stmt().expect("do-while com bloco válido")
+        else {
             panic!("esperava Stmt::DoWhile");
         };
         let Stmt::Block(stmts, _) = *body else {
@@ -649,7 +665,8 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for válido") else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for válido")
+        else {
             panic!("esperava Stmt::For");
         };
         let init_stmt = init.expect("esperava init");
@@ -689,7 +706,8 @@ mod tests {
             eof(28),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for com expr init válido") else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for com expr init válido")
+        else {
             panic!("esperava Stmt::For");
         };
         let init_stmt = init.expect("esperava init");
@@ -723,7 +741,8 @@ mod tests {
             eof(23),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, _, _) = parser.parse_stmt().expect("for com init vazio válido") else {
+        let Stmt::For(init, cond, inc, _, _) = parser.parse_stmt().expect("for com init vazio válido")
+        else {
             panic!("esperava Stmt::For");
         };
         assert!(init.is_none());
@@ -745,7 +764,8 @@ mod tests {
             eof(12),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for (;;) válido") else {
+        let Stmt::For(init, cond, inc, body, _) = parser.parse_stmt().expect("for (;;) válido")
+        else {
             panic!("esperava Stmt::For");
         };
         assert!(init.is_none());
@@ -778,7 +798,8 @@ mod tests {
             eof(28),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::For(_, _, inc, _, _) = parser.parse_stmt().expect("for sem inc válido") else {
+        let Stmt::For(_, _, inc, _, _) = parser.parse_stmt().expect("for sem inc válido")
+        else {
             panic!("esperava Stmt::For");
         };
         assert!(inc.is_none());
@@ -806,7 +827,8 @@ mod tests {
             eof(46),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::Switch(expr, cases, _) = parser.parse_stmt().expect("switch válido") else {
+        let Stmt::Switch(expr, cases, _) = parser.parse_stmt().expect("switch válido")
+        else {
             panic!("esperava Stmt::Switch");
         };
         assert!(matches!(expr, Expr::Ident(name, _) if name == "x"));
@@ -852,7 +874,8 @@ mod tests {
             eof(68),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch com múltiplos cases válido") else {
+        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch com múltiplos cases válido")
+        else {
             panic!("esperava Stmt::Switch");
         };
         assert_eq!(cases.len(), 3);
@@ -880,7 +903,8 @@ mod tests {
             eof(31),
         ];
         let mut parser = Parser::new(tokens);
-        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch default-only válido") else {
+        let Stmt::Switch(_, cases, _) = parser.parse_stmt().expect("switch default-only válido")
+        else {
             panic!("esperava Stmt::Switch");
         };
         assert_eq!(cases.len(), 1);


### PR DESCRIPTION
## Descrição
Implementa parsing das construções de controle de fluxo `for` e `switch` no parser. Os nós AST `Stmt::Switch`, `SwitchCase` e `SwitchLabel` foram adicionados (`Stmt::For` já existia).

## Mudanças

**AST (`src/common/ast/stmt.rs`)**
- Adicionado `Stmt::Switch(Expr, Vec<SwitchCase>, Span)`
- Adicionado `SwitchCase { label: SwitchLabel, stmts: Vec<Stmt>, span: Span }`
- Adicionado `SwitchLabel::Case(Expr)` e `SwitchLabel::Default`

**Parser (`src/parser/rules/statements/basic.rs`)**
- **`parse_for`** — `for ( (decl | expr_stmt | ;) expr? ; expr? ) stmt`
  - Init vazio (`;`), VarDecl ou ExprStmt com lookahead via `starts_type`
  - Condição e incremento opcionais
- **`parse_switch`** — `switch (expr) { (case expr : stmt* | default : stmt*)* }`
  - Stmts dentro de cada case até o próximo `case`/`default`/`}`
- Dispatcher atualizado com `TokenKind::For` e `TokenKind::Switch`

**Testes (`src/tests/parser_test.rs`) — 8 testes novos**

| Teste | O que cobre |
|---|---|
| `parses_for_with_var_decl_init` | `for (int i = 0; i < 10; i++) {}` (critério de aceite) |
| `parses_for_with_expr_init` | `for (i = 0; i < 10; i++) {}` |
| `parses_for_empty_init` | `for (; i < 10; i++) {}` |
| `parses_for_no_cond_no_inc` | `for (;;) {}` |
| `parses_for_no_inc` | `for (int i = 0; i < 10;) {}` |
| `parses_switch_with_case_and_default` | `switch(x) { case 1: break; default: break; }` (critério de aceite) |
| `parses_switch_multiple_cases` | switch com 3 cases e múltiplos stmts |
| `parses_switch_default_only` | `switch(x) { default: break; }` |

**README** — Contagem de testes atualizada de 30 para 38

## Critérios de aceite
- [x] `for (int i = 0; i < 10; i++) {}` parseado sem erro, gerando AST correto
- [x] `switch(x) { case 1: break; default: break; }` parseado sem erro, gerando AST correto
- [x] Dispatcher reconhece `for` e `switch`
- [x] Testes unitários cobrindo os casos acima (88/88 passam)

#72 