### PR TITLE
fix: remove expression terminator check from parse_expr to fix recurs…

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -63,15 +63,6 @@ impl Parser {
             }
         }
 
-        if !self.is_expression_terminator(self.peek_kind()) {
-            let found = self.peek().clone();
-            return Err(self.syntax_error(
-                &found,
-                "fim de expressão",
-                &format!("{:?}", found.kind),
-            ));
-        }
-
         Ok(lhs)
     }
 
@@ -152,20 +143,6 @@ impl Parser {
             column_start: start.column_start,
             column_end: end.column_end,
         }
-    }
-
-    /// Retorna `true` se o token indica um terminador de expressão válido (`;`, `)`, `]`, etc.).
-    fn is_expression_terminator(&self, kind: &TokenKind) -> bool {
-        matches!(
-            kind,
-            TokenKind::Eof
-                | TokenKind::Comma
-                | TokenKind::RightParen
-                | TokenKind::RightBracket
-                | TokenKind::Colon
-                | TokenKind::Semicolon
-                | TokenKind::RightBrace
-        )
     }
 
     /// Constrói um `CompilerError::Syntax` com o span do token, o que era esperado e o que foi encontrado.

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -6,6 +6,7 @@ mod tests {
     use crate::common::input::span::ByteSpan;
     use crate::lexer::tokens::token::Token;
     use crate::lexer::tokens::token_kind::TokenKind;
+    use crate::parser::rules::statements::parse_stmt;
     use crate::parser::Parser;
 
     fn tk(kind: TokenKind, col: usize) -> Token {
@@ -193,10 +194,16 @@ mod tests {
 
     #[test]
     fn rejects_invalid_operator_tokens() {
-        let tokens = vec![int(1, 1), tk(TokenKind::Unknown('?'), 2), int(2, 3), eof(4)];
+        let tokens = vec![
+            int(1, 1),
+            tk(TokenKind::Unknown('?'), 2),
+            int(2, 3),
+            tk(TokenKind::Semicolon, 4),
+            eof(5),
+        ];
 
         let mut parser = Parser::new(tokens);
-        assert!(parser.parse_expr(0).is_err());
+        assert!(parse_stmt(&mut parser).is_err());
     }
 
     #[test]
@@ -211,6 +218,70 @@ mod tests {
 
         let mut parser = Parser::new(tokens);
         assert!(parser.parse_expr(0).is_err());
+    }
+
+    #[test]
+    fn cast_followed_by_binop_parses_correctly() {
+        // (int)a + b → Binary(Cast(int, a), +, b)
+
+        let tokens = vec![
+            tk(TokenKind::LeftParen, 1),
+            tk(TokenKind::Int, 2),
+            tk(TokenKind::RightParen, 3),
+            ident("a", 4),
+            tk(TokenKind::Plus, 5),
+            ident("b", 6),
+            eof(7),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        //inicia a chamada recursiva do Pratt Parser
+        let result = parser.parse_expr(0);
+
+        assert!(result.is_ok(), "O parsing façhpu: {:?}", result);
+
+        // salva a árvore completa gerada do Pratt Parser
+        let ast = result.unwrap();
+
+        // se ast for do tipo binário salva o bagulho da esq, operador, e o bagulho da direita
+        if let Expr::Binary(lhs, op, _rhs, _) = ast {
+            assert_eq!(op, BinOp::Add); // verifica se o op é "+"
+
+            assert!(matches!(*lhs, Expr::Cast(_, _, _))); //
+        } else {
+            panic!("Esperado Expr::BInary na raiz, mas veio: {:?}", ast);
+        }
+    }
+
+    #[test]
+    fn sizeof_followed_by_binop_parses_correctly() {
+        // sizeof x + 1 → Binary(Sizeof(x), +, 1)
+
+        let tokens = vec![
+            tk(TokenKind::Sizeof, 1),
+            ident("x", 2),
+            tk(TokenKind::Plus, 3),
+            int(1, 4),
+            eof(5),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let result = parser.parse_expr(0);
+
+        assert!(result.is_ok(), "O parsing do sizeof falhou: {:?}", result);
+
+        let ast = result.unwrap();
+
+        if let Expr::Binary(lhs, op, _rhs, _) = ast {
+            assert_eq!(op, BinOp::Add);
+
+            assert!(matches!(*lhs, Expr::Sizeof(_, _)));
+        } else {
+            panic!(
+                "Esperado Expr::Binary na raiz para o sizeof, mas veio {:?}",
+                ast
+            );
+        }
     }
 
     #[test]

--- a/src/tests/test_especials_character.rs
+++ b/src/tests/test_especials_character.rs
@@ -1,0 +1,18 @@
+use crate::common::input::source::SourceFile;
+
+#[test]
+fn test_utf8_char_boundaries() {
+let mut sf = SourceFile::from_string("á b");
+
+assert_eq!(sf.peek(), Some('á'));
+
+let ch = sf.advance();
+assert_eq!(ch,Some('á'));
+assert_eq!(sf.pos, 2);
+
+assert_eq!(sf.peek(), Some(' '));
+sf.advance();
+
+assert_eq!(sf.peek(), Some('b'));
+assert_eq!(sf.pos, 3);
+}

--- a/src/tests/unmap_safe_test.rs
+++ b/src/tests/unmap_safe_test.rs
@@ -1,0 +1,24 @@
+#[test]
+fn test_nmap_unsafe_mapping(){
+    use std::fs::File;
+    use std::io::Write;
+    use crate::common::input::source::{SourceData, SourceFile};
+
+    let path = std::env::temp_dir().join("test_nmap_crusty.c");
+    {
+        let mut file = File::create(&path).expect("Num deu pra criar o arquivo!");
+        writeln!(file, "int x = 42;").expect("Num deu pra escrever no arquivo!");
+    }
+
+    let sf = SourceFile::from_path(path.clone()).expect("Falha ao mapear o arquivo pelo Mmap");
+
+    match sf.source{
+        SourceData::Mapped(_) => println!("Deu bão: O arquivo está mapeado em memória virtual!"),
+        SourceData::Memory(_) => panic!("Deu ruim: O sistema usou String em vez do Mmap!"),
+    }
+
+    assert_eq!(sf.source.as_str().trim(), "int x = 42;");
+
+    let _ = std::fs::remove_file(path);
+
+}


### PR DESCRIPTION
# fix: Correção do bloqueio de parsing em expressões recursivas (Cast/Sizeof)

## Descrição
Este PR corrige um bug crítico no motor de parsing do Crusty (Pratt Parser). Anteriormente, a função `parse_expr` tentava validar de forma centralizada se o próximo token era um terminador válido (utilizando o método `is_expression_terminator`). Esse comportamento quebrava a recursividade natural do algoritmo de Pratt ao analisar expressões onde operadores unários de alta precedência eram seguidos por operadores binários de menor precedência, como nos cenários:
* `(int)a + b` (O parser travava logo após o identificador `a`)
* `sizeof x + 1` (O parser travava logo após o identificador `x`)

## O que foi feito
* **Remoção da Trava Central:** Removido o bloco `if !self.is_expression_terminator(...)` de dentro do loop principal da função `parse_expr` no arquivo `src/parser/parser.rs`.
* **Delegação de Responsabilidade:** A responsabilidade de fiscalizar e consumir os terminadores de linha (como `;`) ou fechamento de escopos (como `)`) foi totalmente delegada para os respetivos chamadores macros (Statement Parsers localizados em `src/parser/rules/statements/basic.rs`), que já possuíam essa lógica implementada nativamente.
* **Ajuste na Declaração de Variáveis:** Corrigida a função `parse_var_decl` para evitar o consumo duplicado de pontos e vírgulas (`Semicolon`), harmonizando o fluxo com o novo comportamento do parser de expressões.
* **Limpeza de Código Morto:** O método auxiliar `is_expression_terminator` foi removido por ter se tornado código obsoleto.

## Testes Automatizados
Adicionados e validados com sucesso os testes de regressão específicos para garantir que a árvore sintática (AST) seja montada na precedência correta:
1. `cast_followed_by_binop_parses_correctly` -> Garante a estrutura `Binary(Cast(..), +, ..)`
2. `sizeof_followed_by_binop_parses_correctly` -> Garante a estrutura `Binary(Sizeof(..), +, ..)`
3. Ajustado o teste existente `rejects_invalid_operator_tokens` para validar a rejeição através do escopo correto de Statements (`parse_stmt`).

Resultado do pipeline local:
`test result: ok. 96 passed; 0 failed; 0 ignored;`
Código formatado com `cargo fmt` e verificado com `cargo clippy` (0 warnings).

Closes #82