### PR TITLE
fix: corrige parsing do sizeof impedindo colisão com type cast

### DIFF
--- a/src/common/ast/expr.rs
+++ b/src/common/ast/expr.rs
@@ -71,7 +71,10 @@ pub enum Expr {
     Index(Box<Expr>, Box<Expr>, Span),
     Assign(Box<Expr>, Box<Expr>, Span),
     Sizeof(Box<Expr>, Span),
+
+    // Variante criada para isolar a representação semântica de tamanhos de TIPOS
     SizeofType(QualifierType, Span),
+
     Ternary(Box<Expr>, Box<Expr>, Box<Expr>, Span),
     Member(Box<Expr>, MemberAccess, String, Span),
 }

--- a/src/common/ast/expr.rs
+++ b/src/common/ast/expr.rs
@@ -91,7 +91,7 @@ impl Expr {
             Expr::Index(_, _, s) => s.clone(),
             Expr::Assign(_, _, s) => s.clone(),
             Expr::Sizeof(_, s) => s.clone(),
-            Expr::SizeofType(_, s)=>s.clone(),
+            Expr::SizeofType(_, s) => s.clone(),
             Expr::Ternary(_, _, _, s) => s.clone(),
             Expr::Member(_, _, _, s) => s.clone(),
         }

--- a/src/common/ast/expr.rs
+++ b/src/common/ast/expr.rs
@@ -71,6 +71,7 @@ pub enum Expr {
     Index(Box<Expr>, Box<Expr>, Span),
     Assign(Box<Expr>, Box<Expr>, Span),
     Sizeof(Box<Expr>, Span),
+    SizeofType(QualifierType, Span),
     Ternary(Box<Expr>, Box<Expr>, Box<Expr>, Span),
     Member(Box<Expr>, MemberAccess, String, Span),
 }
@@ -90,6 +91,7 @@ impl Expr {
             Expr::Index(_, _, s) => s.clone(),
             Expr::Assign(_, _, s) => s.clone(),
             Expr::Sizeof(_, s) => s.clone(),
+            Expr::SizeofType(_, s)=>s.clone(),
             Expr::Ternary(_, _, _, s) => s.clone(),
             Expr::Member(_, _, _, s) => s.clone(),
         }

--- a/src/parser/rules/expressions/prefix.rs
+++ b/src/parser/rules/expressions/prefix.rs
@@ -12,29 +12,35 @@ pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr, CompilerError> {
     let token = parser.peek().clone();
     let kind = parser.peek_kind().clone();
 
-    if kind == TokenKind::Sizeof{
+    if kind == TokenKind::Sizeof {
         let sizeof_token = parser.advance().clone();
 
-        if parser.check(&TokenKind::LeftParen) && starts_type(&parser.peek_next().kind){
+        if parser.check(&TokenKind::LeftParen) && starts_type(&parser.peek_next().kind) {
             parser.expect(&TokenKind::LeftParen, "'(' após sizeof")?; // verifica se é um ( se for consome e passa pro próximo token
 
             let ty = parse_type(parser)?; // vai guardar tudo que faz parte do entendimento do tipo (*int), (unsiged int),...
 
-            let rpar = parser.expect(&TokenKind::RightParen, "')' após tipo do siezeof")?.clone();
+            let rpar = parser
+                .expect(&TokenKind::RightParen, "')' após tipo do siezeof")?
+                .clone();
             let span = parser.join_span(parser.span_of(&sizeof_token), parser.span_of(&rpar)); // pega a localização da posção do siezof até o parêntese da direita
 
             return Ok(Expr::SizeofType(ty, span));
-        } else{
-            let bp = crate::parser::precedence::prefix_binding_power(&sizeof_token.kind).ok_or_else(|| {
-                parser.syntax_error(&sizeof_token, "operador fixo", &format!("{:?}", sizeof_token.kind))
-            })?;
+        } else {
+            let bp = crate::parser::precedence::prefix_binding_power(&sizeof_token.kind)
+                .ok_or_else(|| {
+                    parser.syntax_error(
+                        &sizeof_token,
+                        "operador fixo",
+                        &format!("{:?}", sizeof_token.kind),
+                    )
+                })?;
 
             let rhs = parser.parse_expr(bp)?; // chamada recuriva pros bagulhos da direita
             let span = parser.join_span(parser.span_of(&sizeof_token), rhs.span());
 
             return Ok(Expr::Sizeof(Box::new(rhs), span));
         }
-
     }
 
     if looks_like_cast(parser) {

--- a/src/parser/rules/expressions/prefix.rs
+++ b/src/parser/rules/expressions/prefix.rs
@@ -4,12 +4,38 @@ use crate::common::errors::error_data::Span;
 use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
+use crate::parser::rules::declarations::{parse_type, starts_type};
 
 /// Parseia uma expressão prefix: operadores unários, literais, identificadores, agrupamentos e casts.
 /// É o ponto de entrada principal do lado esquerdo no algoritmo Pratt.
 pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr, CompilerError> {
     let token = parser.peek().clone();
     let kind = parser.peek_kind().clone();
+
+    if kind == TokenKind::Sizeof{
+        let sizeof_token = parser.advance().clone();
+
+        if parser.check(&TokenKind::LeftParen) && starts_type(&parser.peek_next().kind){
+            parser.expect(&TokenKind::LeftParen, "'(' após sizeof")?; // verifica se é um ( se for consome e passa pro próximo token
+
+            let ty = parse_type(parser)?; // vai guardar tudo que faz parte do entendimento do tipo (*int), (unsiged int),...
+
+            let rpar = parser.expect(&TokenKind::RightParen, "')' após tipo do siezeof")?.clone();
+            let span = parser.join_span(parser.span_of(&sizeof_token), parser.span_of(&rpar)); // pega a localização da posção do siezof até o parêntese da direita
+
+            return Ok(Expr::SizeofType(ty, span));
+        } else{
+            let bp = crate::parser::precedence::prefix_binding_power(&sizeof_token.kind).ok_or_else(|| {
+                parser.syntax_error(&sizeof_token, "operador fixo", &format!("{:?}", sizeof_token.kind))
+            })?;
+
+            let rhs = parser.parse_expr(bp)?; // chamada recuriva pros bagulhos da direita
+            let span = parser.join_span(parser.span_of(&sizeof_token), rhs.span());
+
+            return Ok(Expr::Sizeof(Box::new(rhs), span));
+        }
+
+    }
 
     if looks_like_cast(parser) {
         return parse_cast_expr(parser);
@@ -22,8 +48,7 @@ pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr, CompilerError> {
         | TokenKind::PlusPlus
         | TokenKind::MinusMinus
         | TokenKind::Star
-        | TokenKind::Ampersand
-        | TokenKind::Sizeof => {
+        | TokenKind::Ampersand => {
             let op = parser.advance().clone();
             let bp =
                 crate::parser::precedence::prefix_binding_power(&op.kind).ok_or_else(|| {

--- a/src/parser/rules/expressions/prefix.rs
+++ b/src/parser/rules/expressions/prefix.rs
@@ -12,6 +12,7 @@ pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr, CompilerError> {
     let token = parser.peek().clone();
     let kind = parser.peek_kind().clone();
 
+    // Tratamento necessário de lookahead do Token Sizeof impedindo colisão com type cast Ex: sizeof(int)
     if kind == TokenKind::Sizeof {
         let sizeof_token = parser.advance().clone();
 

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1200,4 +1200,48 @@ mod tests {
         assert_eq!(name, "main");
         assert_eq!(body.len(), 2);
     }
+
+    #[test]
+    fn sizeof_type_parses_correctly(){
+        let tokens = vec! [
+            tk(TokenKind::Sizeof, 1),
+            tk(TokenKind::LeftParen, 2),
+            tk(TokenKind::Int, 3),
+            tk(TokenKind::RightParen, 4),
+            eof(5),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let result = parser.parse_expr(0);
+
+        assert!(result.is_ok(), "Falhou ao parsear sizeof(type): {:?}", result);
+        let ast = result.unwrap();
+
+        assert!(matches!(ast, Expr::SizeofType(_, _)));
+    }
+
+    #[test]
+    fn sizeof_expr_with_parens_still_works(){
+        let tokens = vec![
+            tk(TokenKind::Sizeof, 1),
+            tk(TokenKind::LeftParen, 2),
+            ident("x", 3),
+            tk(TokenKind::Plus, 4),
+            int(1, 5),
+            tk(TokenKind::RightParen, 6),
+            eof(7),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let result = parser.parse_expr(0);
+
+        assert!(result.is_ok(), "Falhou ao parser sizeof(expr) com parèntese: {:?}", result);
+        let ast = result.unwrap();
+
+        if let Expr::Sizeof(inner_expr, _) = ast {
+            assert!(matches!(*inner_expr, Expr::Binary(_, BinOp::Add, _, _)));
+        }else{
+            panic!("Esperado Expr::Sizeof para expressão com parêntese, mas veio {:?}", ast);
+        }
+    }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1202,8 +1202,8 @@ mod tests {
     }
 
     #[test]
-    fn sizeof_type_parses_correctly(){
-        let tokens = vec! [
+    fn sizeof_type_parses_correctly() {
+        let tokens = vec![
             tk(TokenKind::Sizeof, 1),
             tk(TokenKind::LeftParen, 2),
             tk(TokenKind::Int, 3),
@@ -1214,14 +1214,18 @@ mod tests {
         let mut parser = Parser::new(tokens);
         let result = parser.parse_expr(0);
 
-        assert!(result.is_ok(), "Falhou ao parsear sizeof(type): {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Falhou ao parsear sizeof(type): {:?}",
+            result
+        );
         let ast = result.unwrap();
 
         assert!(matches!(ast, Expr::SizeofType(_, _)));
     }
 
     #[test]
-    fn sizeof_expr_with_parens_still_works(){
+    fn sizeof_expr_with_parens_still_works() {
         let tokens = vec![
             tk(TokenKind::Sizeof, 1),
             tk(TokenKind::LeftParen, 2),
@@ -1235,13 +1239,20 @@ mod tests {
         let mut parser = Parser::new(tokens);
         let result = parser.parse_expr(0);
 
-        assert!(result.is_ok(), "Falhou ao parser sizeof(expr) com parèntese: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Falhou ao parser sizeof(expr) com parèntese: {:?}",
+            result
+        );
         let ast = result.unwrap();
 
         if let Expr::Sizeof(inner_expr, _) = ast {
             assert!(matches!(*inner_expr, Expr::Binary(_, BinOp::Add, _, _)));
-        }else{
-            panic!("Esperado Expr::Sizeof para expressão com parêntese, mas veio {:?}", ast);
+        } else {
+            panic!(
+                "Esperado Expr::Sizeof para expressão com parêntese, mas veio {:?}",
+                ast
+            );
         }
     }
 }


### PR DESCRIPTION
# fix: Tratamento de lookahead para o operador Sizeof em expressões e tipos

## Descrição
Este PR resolve o bug onde a construção `sizeof(int)` quebrava o motor de parsing do compilador. Como o analisador identificava o token `(` seguido de um tipo primitivo, o fluxo era incorretamente desviado para o detector de Cast (`looks_like_cast`), que por sua vez falhava ao tentar consumir uma expressão inexistente após o tipo.

## O que foi feito
* **Interceptação Preventiva:** Adicionado um bloco de checagem exclusiva para `TokenKind::Sizeof` no topo da função `parse_prefix_expr`, capturando o operador antes que o detector de Cast seja acionado.
* **Lookahead de Tipo:** Implementada uma validação combinando `parser.check` e `starts_type` para inspecionar os tokens seguintes sem consumi-los, diferenciando cenários de tipos puros (`sizeof(int)`) de expressões agrupadas (`sizeof(x + 1)`).
* **Nova Variante na AST:** Criada a variante `Expr::SizeofType(QualifierType, Span)` no enum de expressões para isolar a representação semântica de tamanhos de tipos, com a respectiva exaustividade tratada no método de extração de `Span`.
* **Organização do Match:** Removida a duplicidade do token `Sizeof` no mapeamento de precedências gerais do Pratt Parser interno.

## Testes Automatizados
Adicionados e validados com sucesso os testes unitários estruturais em `src/tests/parser_test.rs`:
1. `sizeof_type_parses_correctly` -> Garante o mapeamento para `Expr::SizeofType` ao ler um tipo puro envolvido em parênteses.
2. `sizeof_expr_with_parens_still_works` -> Garante o comportamento legado (fallback) avaliando expressões matemáticas internas como `Expr::Sizeof(Box<Expr::Binary>)`.

Resultado do pipeline local:
`test result: ok. 98 passed; 0 failed; 0 ignored;`

## Issues Relacionadas
Closes #83 