### PR TITLE
feat: Implementei a estrutura de dados da tabela de simbolos

### DIFF
--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod symbol_table;

--- a/src/analyser/symbol_table.rs
+++ b/src/analyser/symbol_table.rs
@@ -1,0 +1,56 @@
+use crate::common::ast::ast::QualifierType;
+use crate::common::errors::{
+    error_data::Span,
+    types::{CompilerError, SemanticError, SemanticErrorKind},
+};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct Symbol {
+    pub name: String,
+    pub ty: QualifierType,
+    pub mutable: bool,
+    pub decl_span: Span,
+}
+
+#[derive(Debug, Default)]
+pub struct SymbolTable {
+    scopes: Vec<HashMap<String, Symbol>>,
+}
+
+impl SymbolTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn enter_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    pub fn exit_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    /// Declara um símbolo no escopo atual. Erro se já declarado no mesmo escopo.
+    pub fn declare(&mut self, symbol: Symbol) -> Result<(), CompilerError> {
+        let scope = self.scopes.last_mut().expect("nenhum escopo ativado");
+        if scope.contains_key(&symbol.name) {
+            return Err(CompilerError::Semantic(SemanticError {
+                span: symbol.decl_span.clone(),
+                kind: SemanticErrorKind::Redeclaration(symbol.name.clone()),
+            }));
+        }
+        scope.insert(symbol.name.clone(), symbol);
+        Ok(())
+    }
+
+    /// Busca o escopo do mais interno para o mais externo
+    pub fn lookup(&self, name: &str) -> Option<&Symbol> {
+        self.scopes.iter().rev().find_map(|s| s.get(name))
+    }
+
+    /// Busca apenas o escopo atual
+    pub fn lookup_current_scope(&self, name: &str) -> Option<&Symbol> {
+        self.scopes.last()?.get(name)
+    }
+}

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -115,6 +115,7 @@ impl ToReport for SyntaxError {
 #[derive(Debug)]
 pub enum SemanticErrorKind {
     UndefinedVariable(String),
+    Redeclaration(String),
     TypeMismatch { expected: String, found: String },
 }
 
@@ -132,6 +133,13 @@ impl ToReport for SemanticError {
                 .with_span(self.span.clone())
                 .with_label(self.span.clone(), format!("'{}' nao existe", var))
                 .with_help("declare a variavel antes de usar"),
+            SemanticErrorKind::Redeclaration(name) => Report::new("Redeclaration error")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    format!("'{}' já foi declarado neste escopo", name),
+                )
+                .with_help("use um nome diferente ou remova a declaração duplicada"),
             SemanticErrorKind::TypeMismatch { expected, found } => Report::new("type error")
                 .with_span(self.span.clone())
                 .with_label(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,4 +4,5 @@ mod lexical_test;
 mod literals_test;
 mod parser_test;
 mod source_test;
+mod symbol_test;
 mod token_test;

--- a/src/tests/symbol_test.rs
+++ b/src/tests/symbol_test.rs
@@ -1,0 +1,164 @@
+// src/tests/symbol_table_test.rs
+
+#[cfg(test)]
+mod tests {
+    use crate::analyser::symbol_table::{Symbol, SymbolTable};
+    use crate::common::ast::ast::{QualifierType, Type};
+    use crate::common::errors::error_data::Span;
+    use crate::common::errors::types::CompilerError;
+    use crate::common::errors::types::SemanticErrorKind;
+
+    fn span() -> Span {
+        Span {
+            line: 1,
+            end_line: 1,
+            column_start: 1,
+            column_end: 2,
+        }
+    }
+
+    fn sym(name: &str, ty: Type, is_const: bool) -> Symbol {
+        Symbol {
+            name: name.to_string(),
+            ty: QualifierType {
+                ty,
+                is_const,
+                is_unsigned: false,
+            },
+            mutable: !is_const,
+            decl_span: span(),
+        }
+    }
+
+    // ── lookup ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn lookup_returns_none_for_undeclared() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        assert!(table.lookup("x").is_none());
+    }
+
+    #[test]
+    fn lookup_finds_declared_symbol() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+        assert!(table.lookup("x").is_some());
+    }
+
+    #[test]
+    fn lookup_traverses_outer_scopes() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+        table.enter_scope();
+        // x foi declarado no escopo externo; deve ser encontrado no interno
+        let found = table.lookup("x");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "x");
+    }
+
+    // ── shadowing ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn inner_scope_shadows_outer() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+
+        table.enter_scope();
+        table.declare(sym("x", Type::Float, false)).unwrap();
+
+        // lookup retorna o do escopo mais interno
+        let found = table.lookup("x").unwrap();
+        assert!(matches!(found.ty.ty, Type::Float));
+    }
+
+    // ── redeclaration ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn redeclaration_in_same_scope_errors() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+
+        let err = table.declare(sym("x", Type::Int, false)).unwrap_err();
+        assert!(matches!(
+            err,
+            CompilerError::Semantic(ref e)
+                if matches!(e.kind, SemanticErrorKind::Redeclaration(_))
+        ));
+    }
+
+    #[test]
+    fn redeclaration_in_different_scopes_is_ok() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+        table.enter_scope();
+        // escopo diferente → não é redeclaração
+        assert!(table.declare(sym("x", Type::Float, false)).is_ok());
+    }
+
+    // ── exit_scope ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn exit_scope_removes_declarations() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.enter_scope();
+        table.declare(sym("y", Type::Int, false)).unwrap();
+        assert!(table.lookup("y").is_some());
+
+        table.exit_scope();
+        assert!(table.lookup("y").is_none());
+    }
+
+    #[test]
+    fn exit_scope_preserves_outer_symbols() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("outer", Type::Int, false)).unwrap();
+
+        table.enter_scope();
+        table.declare(sym("inner", Type::Float, false)).unwrap();
+        table.exit_scope();
+
+        assert!(table.lookup("outer").is_some());
+        assert!(table.lookup("inner").is_none());
+    }
+
+    // ── lookup_current_scope ──────────────────────────────────────────────────
+
+    #[test]
+    fn lookup_current_scope_ignores_outer() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+
+        table.enter_scope();
+        // x está no escopo externo; current_scope não deve encontrar
+        assert!(table.lookup_current_scope("x").is_none());
+    }
+
+    #[test]
+    fn lookup_current_scope_finds_local() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("x", Type::Int, false)).unwrap();
+        assert!(table.lookup_current_scope("x").is_some());
+    }
+
+    // ── qualificadores ────────────────────────────────────────────────────────
+
+    #[test]
+    fn const_symbol_is_not_mutable() {
+        let mut table = SymbolTable::new();
+        table.enter_scope();
+        table.declare(sym("PI", Type::Float, true)).unwrap();
+        let found = table.lookup("PI").unwrap();
+        assert!(!found.mutable);
+        assert!(found.ty.is_const);
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the parser and semantic analysis infrastructure, with a focus on handling `sizeof` expressions, type casting, and introducing a robust symbol table for semantic checks. It also adds comprehensive tests to ensure correctness of parsing, symbol table behavior, and special character handling. The main changes are grouped below
### Parser and AST Enhancements

* Added a new `Expr::SizeofType(QualifierType, Span)` variant to the AST to distinguish between `sizeof(type)` and `sizeof(expr)`, and updated the parser logic to correctly parse both forms. 
* Removed unnecessary expression terminator checks in the parser, simplifying expression parsing and error handling. 

### Symbol Table and Semantic Analysis

* Introduced a `symbol_table` module implementing a scoped symbol table with support for declaration, lookup, shadowing, and redeclaration error detection. 
* Extended `SemanticErrorKind` with a `Redeclaration` variant and improved error reporting for redeclaration cases. 

### Testing Improvements

* Added comprehensive tests for the symbol table, covering lookups, shadowing, redeclaration, scope management, and qualifiers. 
* Enhanced parser tests to verify correct parsing of cast expressions, `sizeof` in both forms, and binary operations following these constructs. 
* Added new tests for UTF-8 character boundary handling and memory-mapped file source input.