### PR TITLE
feat(parser): recuperação de erros sintáticos - panic mode (issue #100)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,13 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
                 println!("{:#?}", decl);
             }
         }
-        Err(e) => {
-            print_report(&e.to_report());
-            return Err(Box::new(DiagnosticError { count: 1 }));
+        Err(errors) => {
+            let count = errors.len();
+            eprintln!("\n=== Syntax Errors ({count}) ===");
+            for e in &errors {
+                print_report(&e.to_report());
+            }
+            return Err(Box::new(DiagnosticError { count }));
         }
     }
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -17,7 +17,11 @@ pub struct Parser {
 
 impl Parser {
     pub fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, pos: 0, diagnostics: Vec::new() }
+        Self {
+            tokens,
+            pos: 0,
+            diagnostics: Vec::new(),
+        }
     }
 
     pub(crate) fn peek_next(&self) -> &Token {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -9,16 +9,15 @@ use crate::parser::rules::expressions::{infix, postfix, prefix};
 
 type Diagnostic = CompilerError;
 
-// Estrutura mínima pedida: apenas fluxo de tokens para parser de expressões.
 pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
+    pub(crate) diagnostics: Vec<CompilerError>,
 }
 
 impl Parser {
-    /// Cria um novo `Parser` a partir de um vetor de tokens produzido pelo `Scanner`.
     pub fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, pos: 0 }
+        Self { tokens, pos: 0, diagnostics: Vec::new() }
     }
 
     pub(crate) fn peek_next(&self) -> &Token {
@@ -74,8 +73,24 @@ impl Parser {
     }
 
     /// Parseia um programa C completo: declarações globais até EOF.
-    pub fn parse_program(&mut self) -> Result<Program, Diagnostic> {
+    /// Retorna `Ok(Program)` se sem erros, ou `Err(Vec<CompilerError>)` com todos os erros acumulados.
+    pub fn parse_program(&mut self) -> Result<Program, Vec<CompilerError>> {
         crate::parser::rules::declarations::parse_program(self)
+    }
+
+    /// Avança tokens até o próximo ponto de sincronização (`;`, `}` ou EOF), consumindo o delimitador.
+    pub(crate) fn synchronize(&mut self) {
+        while !self.is_at_end() {
+            match self.peek_kind() {
+                TokenKind::Semicolon | TokenKind::RightBrace => {
+                    self.advance();
+                    return;
+                }
+                _ => {
+                    self.advance();
+                }
+            }
+        }
     }
 
     /// Retorna o token atual sem avançar a posição.

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -8,12 +8,23 @@ use crate::parser::parser::Parser;
 use crate::parser::rules::declarations::types::parse_type;
 
 /// Parseia um programa C completo: sequência de declarações globais até EOF.
-pub fn parse_program(parser: &mut Parser) -> Result<Program, CompilerError> {
+/// Ao encontrar erro, sincroniza no próximo `;` ou `}` e continua, acumulando todos os erros.
+pub fn parse_program(parser: &mut Parser) -> Result<Program, Vec<CompilerError>> {
     let mut decls = Vec::new();
     while !parser.is_at_end() {
-        decls.push(parse_global_item(parser)?);
+        match parse_global_item(parser) {
+            Ok(decl) => decls.push(decl),
+            Err(e) => {
+                parser.diagnostics.push(e);
+                parser.synchronize();
+            }
+        }
     }
-    Ok(Program { decls })
+    if parser.diagnostics.is_empty() {
+        Ok(Program { decls })
+    } else {
+        Err(std::mem::take(&mut parser.diagnostics))
+    }
 }
 
 /// Dispatcher do escopo global: tipo + lookahead para distinguir função de variável global.

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1240,6 +1240,78 @@ mod tests {
         ));
     }
 
+    // ── Testes de recuperação de erros (panic mode) ──────────────────────────
+
+    #[test]
+    fn reports_single_syntax_error_in_program() {
+        // int 42;  →  esperado identificador, encontrado IntLiteral
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            int(42, 5),
+            tk(TokenKind::Semicolon, 7),
+            eof(8),
+        ];
+        let result = Parser::new(tokens).parse_program();
+        let errors = result.expect_err("deveria falhar com erro de sintaxe");
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn reports_multiple_syntax_errors_in_program() {
+        // int 42;   float 99;  →  dois erros, ambos reportados
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            int(42, 5),
+            tk(TokenKind::Semicolon, 7),
+            tk(TokenKind::Float, 9),
+            int(99, 15),
+            tk(TokenKind::Semicolon, 17),
+            eof(18),
+        ];
+        let result = Parser::new(tokens).parse_program();
+        let errors = result.expect_err("deveria acumular erros");
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    fn continues_parsing_valid_decl_after_error() {
+        // int 42;  float z;  →  1 erro + 1 decl válida (float z)
+        // parse_program retorna Err porque há erros, mas o count é 1
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            int(42, 5),
+            tk(TokenKind::Semicolon, 7),
+            tk(TokenKind::Float, 9),
+            ident("z", 15),
+            tk(TokenKind::Semicolon, 16),
+            eof(17),
+        ];
+        let result = Parser::new(tokens).parse_program();
+        let errors = result.expect_err("deveria ter 1 erro");
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn recovers_after_unclosed_function_body() {
+        // int bad(void) { return   ← erro por EOF dentro do bloco
+        // int ok;                  ← decl separada (não chega a ser parseada pois sync vai ao EOF)
+        // Apenas verifica que parse_program não entra em loop infinito e retorna erros.
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            ident("bad", 5),
+            tk(TokenKind::LeftParen, 8),
+            tk(TokenKind::Void, 9),
+            tk(TokenKind::RightParen, 13),
+            tk(TokenKind::LeftBrace, 15),
+            tk(TokenKind::Return, 17),
+            eof(23),
+        ];
+        let result = Parser::new(tokens).parse_program();
+        assert!(result.is_err(), "deveria reportar erro de sintaxe");
+    }
+
+    // ── fim dos testes de recuperação ─────────────────────────────────────────
+
     #[test]
     fn parses_hello_world() {
         // int main() { printf("Hello"); return 0; }


### PR DESCRIPTION
## Summary

- `Parser` ganha campo `diagnostics: Vec<CompilerError>` e método `synchronize()`, espelhando o padrão já usado pelo `Scanner`
- `parse_program` passa de `Result<Program, CompilerError>` para `Result<Program, Vec<CompilerError>>`: ao encontrar erro, registra no vetor, avança até o próximo `;` ou `}` (panic mode) e continua parseando
- `main.rs` atualizado para exibir todos os erros sintáticos acumulados
- 4 novos testes: erro único, múltiplos erros, recuperação parcial (decl válida após erro), e recuperação por EOF

## Test plan

- [x] `reports_single_syntax_error_in_program` — 1 erro acumulado
- [x] `reports_multiple_syntax_errors_in_program` — 2 erros acumulados
- [x] `continues_parsing_valid_decl_after_error` — sincroniza e continua
- [x] `recovers_after_unclosed_function_body` — não entra em loop infinito
- [x] Todos os 120 testes existentes continuam passando

Closes #74 
Closes #100