### PR TITLE
Tests: testes de integração com arquivos reais

### DIFF
--- a/src/parser/rules/declarations/types.rs
+++ b/src/parser/rules/declarations/types.rs
@@ -10,6 +10,7 @@ pub fn starts_type(kind: &TokenKind) -> bool {
         TokenKind::Const
             | TokenKind::Unsigned
             | TokenKind::Int
+            | TokenKind::Long
             | TokenKind::Float
             | TokenKind::Double
             | TokenKind::Struct
@@ -37,6 +38,11 @@ pub fn parse_type(parser: &mut Parser) -> Result<QualifierType, CompilerError> {
     let base = match parser.peek_kind() {
         TokenKind::Int => {
             parser.advance();
+            Type::Int
+        }
+        TokenKind::Long => {
+            parser.advance();
+            // A AST ainda não possui Type::Long; tratamos como inteiro por ora.
             Type::Int
         }
         TokenKind::Char => {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod ast_errors;
 mod lexer_file_test;
 mod lexical_test;
 mod literals_test;
+mod parser_file_test;
 mod parser_test;
 mod source_test;
 mod token_test;

--- a/src/tests/parser_file_test.rs
+++ b/src/tests/parser_file_test.rs
@@ -77,7 +77,9 @@ mod tests {
         });
         assert!(has_printf_call, "esperava chamada printf no corpo de main");
 
-        let has_return = body.iter().any(|stmt| matches!(stmt, Stmt::Return(Some(_), _)));
+        let has_return = body
+            .iter()
+            .any(|stmt| matches!(stmt, Stmt::Return(Some(_), _)));
         assert!(has_return, "esperava return com valor no corpo de main");
     }
 
@@ -106,6 +108,9 @@ mod tests {
             );
         });
 
-        assert!(result.is_ok(), "pipeline não deve panicar em erro sintático");
+        assert!(
+            result.is_ok(),
+            "pipeline não deve panicar em erro sintático"
+        );
     }
 }

--- a/src/tests/parser_file_test.rs
+++ b/src/tests/parser_file_test.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use crate::common::ast::ast::Program;
+    use crate::common::ast::decl::Decl;
+    use crate::common::ast::expr::{Expr, Literal};
+    use crate::common::ast::stmt::Stmt;
+    use crate::common::input::source::SourceFile;
+    use crate::lexer::scanner::Scanner;
+    use crate::parser::Parser;
+    use std::fs;
+    use std::panic;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    fn parse_file(name: &str) -> Program {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/examples")
+            .join(name);
+        let src = SourceFile::from_path(path)
+            .unwrap_or_else(|e| panic!("failed to read '{}': {:?}", name, e.to_report()));
+
+        let mut scanner = Scanner::new(src);
+        scanner.scan();
+        assert!(
+            scanner.diagnostics.is_empty(),
+            "esperado zero erros lexicais em {name}, obtido {}",
+            scanner.diagnostics.len()
+        );
+
+        let mut parser = Parser::new(scanner.tokens);
+        parser
+            .parse_program()
+            .unwrap_or_else(|e| panic!("falha ao parsear '{}': {:?}", name, e))
+    }
+
+    #[test]
+    fn full_code1_has_one_main_function_decl() {
+        let program = parse_file("full_code1.c");
+
+        assert_eq!(program.decls.len(), 1, "esperado 1 declaração global");
+        assert!(matches!(
+            &program.decls[0],
+            Decl::Function(_, name, _, _, _) if name == "main"
+        ));
+    }
+
+    #[test]
+    fn declarations_has_five_global_vars() {
+        let program = parse_file("declarations.c");
+
+        assert_eq!(program.decls.len(), 5, "esperado 5 declarações globais");
+        assert!(program
+            .decls
+            .iter()
+            .all(|d| matches!(d, Decl::GlobalVar(_, _, _, _))));
+    }
+
+    #[test]
+    fn hello_world_has_printf_call_and_return() {
+        let program = parse_file("hello_world.c");
+
+        assert_eq!(program.decls.len(), 1, "esperado programa com 1 função");
+        let Decl::Function(_, name, _, body, _) = &program.decls[0] else {
+            panic!("esperava Decl::Function");
+        };
+        assert_eq!(name, "main");
+
+        let has_printf_call = body.iter().any(|stmt| {
+            matches!(
+                stmt,
+                Stmt::ExprStmt(
+                    Expr::Call(callee, args, _),
+                    _
+                ) if matches!(callee.as_ref(), Expr::Ident(id, _) if id == "printf")
+                    && matches!(args.as_slice(), [Expr::Literal(Literal::String(_), _)])
+            )
+        });
+        assert!(has_printf_call, "esperava chamada printf no corpo de main");
+
+        let has_return = body.iter().any(|stmt| matches!(stmt, Stmt::Return(Some(_), _)));
+        assert!(has_return, "esperava return com valor no corpo de main");
+    }
+
+    #[test]
+    fn syntax_error_file_reports_diagnostic_without_panic() {
+        let result = panic::catch_unwind(|| {
+            let tmp = tempdir().expect("falha ao criar diretório temporário");
+            let file_path = tmp.path().join("syntax_error.c");
+
+            // Falta '}' de fechamento para forçar erro sintático no parser.
+            fs::write(&file_path, "int main() {\n    return 0;\n")
+                .expect("falha ao gravar arquivo temporário");
+
+            let src = SourceFile::from_path(file_path)
+                .expect("falha ao abrir arquivo temporário via SourceFile");
+            let mut scanner = Scanner::new(src);
+            scanner.scan();
+
+            let mut parser = Parser::new(scanner.tokens);
+            let parse_result = parser.parse_program();
+
+            let diagnostics_count = scanner.diagnostics.len() + usize::from(parse_result.is_err());
+            assert!(
+                diagnostics_count >= 1,
+                "esperado ao menos 1 diagnóstico, obtido {diagnostics_count}"
+            );
+        });
+
+        assert!(result.is_ok(), "pipeline não deve panicar em erro sintático");
+    }
+}


### PR DESCRIPTION
**Tests: testes de integração com arquivos reais**

**Descrição**
- **Contexto:** O analisador do parser não reconhecia o tipo `long` em declarações de tipos, causando falhas ao compilar/executar código que usa `long`.
- **O que foi feito:** Ajustes na lógica de parsing de tipos para aceitar `long` como tipo válido.
- **Motivação:** Corrigir inconsistência com a gramática C alvo do projeto e permitir testes/execuções com declarações que usam `long`.
- **Referência:** branch `feat/issue76-integration-tests` (issue relacionada: #76).

**Mudanças chave**
- **Arquivos alterados:** types.rs

**Como testar**
- Rodar a suíte de testes:
```bash
cargo test
```
- Testes específicos do parser (se desejar rodar apenas os testes de parser):
```bash
cargo test --test parser_test
```
- Verificar compilação do binário:
```bash
cargo build
```

**Checklist**
- **Código compilável:** Sim (último commit)
- **Testes adicionados/atualizados:** Não foram adicionados novos testes neste commit — considere adicionar casos com `long`.
- **Documentação atualizada:** Não aplicável.