### PR TITLE
feat(parser): resolve bug de operadores compostos ignorados pelo parser (issue #85)

### DIFF
--- a/src/common/ast/expr.rs
+++ b/src/common/ast/expr.rs
@@ -70,6 +70,7 @@ pub enum Expr {
     Cast(QualifierType, Box<Expr>, Span),
     Index(Box<Expr>, Box<Expr>, Span),
     Assign(Box<Expr>, Box<Expr>, Span),
+    CompoundAssign(BinOp, Box<Expr>, Box<Expr>, Span),
     Sizeof(Box<Expr>, Span),
 
     // Variante criada para isolar a representação semântica de tamanhos de TIPOS
@@ -93,6 +94,7 @@ impl Expr {
             Expr::Cast(_, _, s) => s.clone(),
             Expr::Index(_, _, s) => s.clone(),
             Expr::Assign(_, _, s) => s.clone(),
+            Expr::CompoundAssign(_, _, _, s) => s.clone(),
             Expr::Sizeof(_, s) => s.clone(),
             Expr::SizeofType(_, s) => s.clone(),
             Expr::Ternary(_, _, _, s) => s.clone(),

--- a/src/lexer/rules/operators.rs
+++ b/src/lexer/rules/operators.rs
@@ -64,6 +64,16 @@ impl OperatorRules for Scanner {
             },
 
             // -------------------------------------------------------
+            // % : %= | %
+            '%' => match self.src.peek() {
+                Some('=') => {
+                    self.src.advance();
+                    self.emit_at(TokenKind::PercentEqual, line, col);
+                }
+                _ => self.emit_at(TokenKind::Percent, line, col),
+            },
+
+            // -------------------------------------------------------
             // = : == | =
             '=' => match self.src.peek() {
                 Some('=') => {
@@ -122,23 +132,41 @@ impl OperatorRules for Scanner {
             },
 
             // -------------------------------------------------------
-            // & : && | &
+            // & : && | &= | &
             '&' => match self.src.peek() {
                 Some('&') => {
                     self.src.advance();
                     self.emit_at(TokenKind::AndAnd, line, col);
                 }
+                Some('=') => {
+                    self.src.advance();
+                    self.emit_at(TokenKind::AmpersandEqual, line, col);
+                }
                 _ => self.emit_at(TokenKind::Ampersand, line, col),
             },
 
             // -------------------------------------------------------
-            // | : || | |
+            // | : || | |= | |
             '|' => match self.src.peek() {
                 Some('|') => {
                     self.src.advance();
                     self.emit_at(TokenKind::OrOr, line, col);
                 }
+                Some('=') => {
+                    self.src.advance();
+                    self.emit_at(TokenKind::PipeEqual, line, col);
+                }
                 _ => self.emit_at(TokenKind::Pipe, line, col),
+            },
+
+            // -------------------------------------------------------
+            // ^ : ^= | ^
+            '^' => match self.src.peek() {
+                Some('=') => {
+                    self.src.advance();
+                    self.emit_at(TokenKind::CaretEqual, line, col);
+                }
+                _ => self.emit_at(TokenKind::Caret, line, col),
             },
 
             // Qualquer outro char cai aqui como desconhecido

--- a/src/lexer/tokens/token_kind.rs
+++ b/src/lexer/tokens/token_kind.rs
@@ -50,10 +50,14 @@ pub enum TokenKind {
     Caret,      // ^
     PlusPlus,   // ++
     MinusMinus, // --
-    PlusEqual,  // +=
-    MinusEqual, // -=
-    StarEqual,  // *=
-    SlashEqual, // /=
+    PlusEqual,       // +=
+    MinusEqual,      // -=
+    StarEqual,       // *=
+    SlashEqual,      // /=
+    PercentEqual,    // %=
+    AmpersandEqual,  // &=
+    PipeEqual,       // |=
+    CaretEqual,      // ^=
 
     // Operadores relacionais / igualdade
     EqualEqual,   // ==

--- a/src/lexer/tokens/token_kind.rs
+++ b/src/lexer/tokens/token_kind.rs
@@ -42,22 +42,22 @@ pub enum TokenKind {
     Dot,   // .
 
     // Operadores aritméticos
-    Plus,       // +
-    Minus,      // -
-    Star,       // *
-    Slash,      // /
-    Percent,    // %
-    Caret,      // ^
-    PlusPlus,   // ++
-    MinusMinus, // --
-    PlusEqual,       // +=
-    MinusEqual,      // -=
-    StarEqual,       // *=
-    SlashEqual,      // /=
-    PercentEqual,    // %=
-    AmpersandEqual,  // &=
-    PipeEqual,       // |=
-    CaretEqual,      // ^=
+    Plus,           // +
+    Minus,          // -
+    Star,           // *
+    Slash,          // /
+    Percent,        // %
+    Caret,          // ^
+    PlusPlus,       // ++
+    MinusMinus,     // --
+    PlusEqual,      // +=
+    MinusEqual,     // -=
+    StarEqual,      // *=
+    SlashEqual,     // /=
+    PercentEqual,   // %=
+    AmpersandEqual, // &=
+    PipeEqual,      // |=
+    CaretEqual,     // ^=
 
     // Operadores relacionais / igualdade
     EqualEqual,   // ==

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -59,6 +59,21 @@ impl Parser {
 
             if op == TokenKind::Equal {
                 lhs = Expr::Assign(Box::new(lhs), Box::new(rhs), span);
+            } else if matches!(
+                op,
+                TokenKind::PlusEqual
+                    | TokenKind::MinusEqual
+                    | TokenKind::StarEqual
+                    | TokenKind::SlashEqual
+                    | TokenKind::PercentEqual
+                    | TokenKind::AmpersandEqual
+                    | TokenKind::PipeEqual
+                    | TokenKind::CaretEqual
+                    | TokenKind::LessLessEqual
+                    | TokenKind::GreaterGreaterEqual
+            ) {
+                let bin_op = infix::token_to_compound_bin_op(self, &op, &op_token)?;
+                lhs = Expr::CompoundAssign(bin_op, Box::new(lhs), Box::new(rhs), span);
             } else {
                 let bin = infix::token_to_bin_op(self, &op, &op_token)?;
                 lhs = Expr::Binary(Box::new(lhs), bin, Box::new(rhs), span);

--- a/src/parser/precedence.rs
+++ b/src/parser/precedence.rs
@@ -8,7 +8,18 @@ use crate::lexer::tokens::token_kind::TokenKind;
 /// `lbp` é o poder de ligação à esquerda e `rbp` à direita, seguindo a tabela de precedência do C.
 pub fn infix_binding_power(op: &TokenKind) -> Option<(u8, u8, bool)> {
     let bp = match op {
-        TokenKind::Equal => (1, 1, false),
+        // Atribuição simples e composta — associatividade à direita (rbp == lbp)
+        TokenKind::Equal
+        | TokenKind::PlusEqual
+        | TokenKind::MinusEqual
+        | TokenKind::StarEqual
+        | TokenKind::SlashEqual
+        | TokenKind::PercentEqual
+        | TokenKind::AmpersandEqual
+        | TokenKind::PipeEqual
+        | TokenKind::CaretEqual
+        | TokenKind::LessLessEqual
+        | TokenKind::GreaterGreaterEqual => (1, 1, false),
         TokenKind::OrOr => (2, 3, false),
         TokenKind::AndAnd => (4, 5, false),
         TokenKind::Pipe => (6, 7, false),

--- a/src/parser/rules/expressions/infix.rs
+++ b/src/parser/rules/expressions/infix.rs
@@ -35,6 +35,36 @@ pub fn token_to_bin_op(
     Ok(op)
 }
 
+/// Converte um `TokenKind` de atribuição composta no `BinOp` da operação subjacente.
+/// Por exemplo, `+=` → `BinOp::Add`, `>>=` → `BinOp::Shr`.
+/// Retorna erro sintático se o token não for um operador de atribuição composta suportado.
+pub fn token_to_compound_bin_op(
+    parser: &Parser,
+    kind: &TokenKind,
+    found: &Token,
+) -> Result<BinOp, CompilerError> {
+    let op = match kind {
+        TokenKind::PlusEqual => BinOp::Add,
+        TokenKind::MinusEqual => BinOp::Sub,
+        TokenKind::StarEqual => BinOp::Mul,
+        TokenKind::SlashEqual => BinOp::Div,
+        TokenKind::PercentEqual => BinOp::Mod,
+        TokenKind::AmpersandEqual => BinOp::BitAnd,
+        TokenKind::PipeEqual => BinOp::BitOr,
+        TokenKind::CaretEqual => BinOp::BitXor,
+        TokenKind::LessLessEqual => BinOp::Shl,
+        TokenKind::GreaterGreaterEqual => BinOp::Shr,
+        _ => {
+            return Err(parser.syntax_error(
+                found,
+                "operador de atribuição composta",
+                &format!("{:?}", kind),
+            ))
+        }
+    };
+    Ok(op)
+}
+
 /// Parseia o operador ternário `? then : else` após o `?` já ter sido consumido.
 pub fn parse_ternary(parser: &mut Parser, lhs: Expr, rbp: u8) -> Result<Expr, CompilerError> {
     let then_expr = parser.parse_expr(rbp)?;

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1362,16 +1362,17 @@ mod tests {
         ];
 
         let mut parser = Parser::new(tokens);
-        let expr = parser
-            .parse_expr(0)
-            .expect("compound assign >>= válido");
+        let expr = parser.parse_expr(0).expect("compound assign >>= válido");
 
         let Expr::CompoundAssign(op, lhs, rhs, _) = expr else {
             panic!("esperava Expr::CompoundAssign para >>=");
         };
         assert_eq!(op, BinOp::Shr);
         assert!(matches!(*lhs, Expr::Ident(ref s, _) if s == "x"));
-        assert!(matches!(*rhs, Expr::Literal(crate::common::ast::expr::Literal::Int(2), _)));
+        assert!(matches!(
+            *rhs,
+            Expr::Literal(crate::common::ast::expr::Literal::Int(2), _)
+        ));
     }
 
     #[test]
@@ -1392,12 +1393,7 @@ mod tests {
         ];
 
         for (token_kind, expected_op) in cases {
-            let tokens = vec![
-                ident("a", 1),
-                tk(token_kind.clone(), 3),
-                int(1, 6),
-                eof(7),
-            ];
+            let tokens = vec![ident("a", 1), tk(token_kind.clone(), 3), int(1, 6), eof(7)];
 
             let mut parser = Parser::new(tokens);
             let expr = parser

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1325,4 +1325,92 @@ mod tests {
             );
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Testes: operadores de atribuição composta
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compound_assign_plus_parses_correctly() {
+        // a += b  →  CompoundAssign(Add, Ident("a"), Ident("b"))
+        let tokens = vec![
+            ident("a", 1),
+            tk(TokenKind::PlusEqual, 3),
+            ident("b", 6),
+            eof(7),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let expr = parser.parse_expr(0).expect("compound assign += válido");
+
+        let Expr::CompoundAssign(op, lhs, rhs, _) = expr else {
+            panic!("esperava Expr::CompoundAssign para +=");
+        };
+        assert_eq!(op, BinOp::Add);
+        assert!(matches!(*lhs, Expr::Ident(ref s, _) if s == "a"));
+        assert!(matches!(*rhs, Expr::Ident(ref s, _) if s == "b"));
+    }
+
+    #[test]
+    fn compound_assign_shift_right_parses_correctly() {
+        // x >>= 2  →  CompoundAssign(Shr, Ident("x"), Literal(2))
+        let tokens = vec![
+            ident("x", 1),
+            tk(TokenKind::GreaterGreaterEqual, 3),
+            int(2, 6),
+            eof(7),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let expr = parser
+            .parse_expr(0)
+            .expect("compound assign >>= válido");
+
+        let Expr::CompoundAssign(op, lhs, rhs, _) = expr else {
+            panic!("esperava Expr::CompoundAssign para >>=");
+        };
+        assert_eq!(op, BinOp::Shr);
+        assert!(matches!(*lhs, Expr::Ident(ref s, _) if s == "x"));
+        assert!(matches!(*rhs, Expr::Literal(crate::common::ast::expr::Literal::Int(2), _)));
+    }
+
+    #[test]
+    fn compound_assign_all_operators_parse() {
+        // Verifica que todos os 10 tokens de compound-assign são reconhecidos pelo parser
+        // e produzem o BinOp correto.
+        let cases: Vec<(TokenKind, BinOp)> = vec![
+            (TokenKind::PlusEqual, BinOp::Add),
+            (TokenKind::MinusEqual, BinOp::Sub),
+            (TokenKind::StarEqual, BinOp::Mul),
+            (TokenKind::SlashEqual, BinOp::Div),
+            (TokenKind::PercentEqual, BinOp::Mod),
+            (TokenKind::AmpersandEqual, BinOp::BitAnd),
+            (TokenKind::PipeEqual, BinOp::BitOr),
+            (TokenKind::CaretEqual, BinOp::BitXor),
+            (TokenKind::LessLessEqual, BinOp::Shl),
+            (TokenKind::GreaterGreaterEqual, BinOp::Shr),
+        ];
+
+        for (token_kind, expected_op) in cases {
+            let tokens = vec![
+                ident("a", 1),
+                tk(token_kind.clone(), 3),
+                int(1, 6),
+                eof(7),
+            ];
+
+            let mut parser = Parser::new(tokens);
+            let expr = parser
+                .parse_expr(0)
+                .unwrap_or_else(|e| panic!("compound assign {:?} falhou: {:?}", token_kind, e));
+
+            let Expr::CompoundAssign(op, _, _, _) = expr else {
+                panic!(
+                    "esperava Expr::CompoundAssign para {:?}, mas veio algo diferente",
+                    token_kind
+                );
+            };
+            assert_eq!(op, expected_op, "BinOp errado para {:?}", token_kind);
+        }
+    }
 }


### PR DESCRIPTION
## feat(lexer/parser): suporte completo a operadores de atribuição composta (`+=`, `-=`, `*=`, `/=`, `%=`, `&=`, `|=`, `^=`, `<<=`, `>>=`)

### Problema

Os operadores de atribuição composta tinham suporte parcial: `+=`, `-=`, `*=`, `/=`, `<<=` e `>>=` já existiam como variantes de `TokenKind` e eram emitidos corretamente pelo scanner, mas `infix_binding_power` nunca os reconhecia. Isso fazia o loop Pratt quebrar imediatamente ao encontrá-los, produzindo uma parse incorreta silenciosamente. Além disso, `%=`, `&=`, `|=` e `^=` estavam completamente ausentes tanto do `TokenKind` quanto do scanner.

### Solução

Implementado suporte completo aos 10 operadores de atribuição composta usando um nó nativo na AST (`Expr::CompoundAssign`), em vez de dessugarar no parser. Essa abordagem preserva a semântica original para as fases de análise semântica e geração de código.

### Alterações

**Lexer**
- `token_kind.rs` — adicionadas as variantes `PercentEqual`, `AmpersandEqual`, `PipeEqual`, `CaretEqual`
- `operators.rs` — adicionado lookahead de `=` nos braços de `%`, `&`, `|`, `^`

**AST**
- `expr.rs` — adicionada a variante `Expr::CompoundAssign(BinOp, Box<Expr>, Box<Expr>, Span)` e seu braço em `span()`

**Parser**
- `precedence.rs` — registrados todos os 10 tokens de atribuição composta em `infix_binding_power` com precedência associativa à direita `(1, 1, false)`, igual ao `=`
- `infix.rs` — adicionada a função `token_to_compound_bin_op`, que mapeia cada token ao seu `BinOp` correspondente
- `parser.rs` — adicionado branch `else if` no loop Pratt para emitir `Expr::CompoundAssign`

## **Tarefas:**
- [x] Adicionar `PercentEqual` (`%=`), `AmpersandEqual` (`&=`), `PipeEqual` (`|=`), `CaretEqual` (`^=`) em `TokenKind` e no scanner
- [x] Decidir estratégia de parsing:
  - **Opção A (dessugarar no parser):** `a += b` → `Assign(a, Binary(a, +, b))` — mais simples, sem mudanças na AST
  - **Opção B (nó nativo):** `Expr::CompoundAssign(BinOp, Box<Expr>, Box<Expr>, Span)` — preserva a semântica original para o semântico
- [x] Adicionar todos os compound assignments em `infix_binding_power` com a mesma precedência de `Equal` `(1, 1, false)`
- [x] Implementar o caso em `parse_expr` (análogo ao `Equal` já existente)

**Testes**
- `compound_assign_plus_parses_correctly` — `a += b` → `CompoundAssign(Add, a, b)`
- `compound_assign_shift_right_parses_correctly` — `x >>= 2` → `CompoundAssign(Shr, x, 2)`
- `compound_assign_all_operators_parse` — teste orientado a tabela cobrindo todos os 10 operadores e seus mapeamentos de `BinOp`

### Resultado dos testes

```
test tests::parser_test::tests::compound_assign_all_operators_parse ... ok
test tests::parser_test::tests::compound_assign_plus_parses_correctly ... ok
test tests::parser_test::tests::compound_assign_shift_right_parses_correctly ... ok
```

---

Closes #85 