### PR TITLE
feat(parser): implementa panic-mode error recovery

### DIFF
--- a/src/common/ast/ast.rs
+++ b/src/common/ast/ast.rs
@@ -1,4 +1,5 @@
 use crate::common::ast::decl::Decl;
+use crate::common::errors::types::CompilerError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
@@ -20,7 +21,10 @@ pub struct QualifierType {
     pub is_unsigned: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// AST do programa, incluindo declarações parseadas e erros coletados durante o parse.
+/// Mesmo com erros, `decls` contém as declarações que foram parseadas com sucesso.
+#[derive(Debug)]
 pub struct Program {
     pub decls: Vec<Decl>,
+    pub errors: Vec<CompilerError>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,17 +76,19 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
     }
 
     let mut parser = Parser::new(scanner.tokens);
-    match parser.parse_program() {
-        Ok(program) => {
-            println!("\n=== AST ({}) ===", program.decls.len());
-            for decl in &program.decls {
-                println!("{:#?}", decl);
-            }
-        }
-        Err(e) => {
+    let program = parser.parse_program();
+
+    if !program.errors.is_empty() {
+        eprintln!("\n=== Parse Errors ({}) ===", program.errors.len());
+        for e in &program.errors {
             print_report(&e.to_report());
-            return Err(Box::new(DiagnosticError { count: 1 }));
         }
+        return Err(Box::new(DiagnosticError { count: program.errors.len() }));
+    }
+
+    println!("\n=== AST ({}) ===", program.decls.len());
+    for decl in &program.decls {
+        println!("{:#?}", decl);
     }
 
     Ok(())

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -13,12 +13,14 @@ type Diagnostic = CompilerError;
 pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
+    /// Erros coletados durante o parse; transferidos para `Program::errors` ao final.
+    pub errors: Vec<CompilerError>,
 }
 
 impl Parser {
     /// Cria um novo `Parser` a partir de um vetor de tokens produzido pelo `Scanner`.
     pub fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, pos: 0 }
+        Self { tokens, pos: 0, errors: Vec::new() }
     }
 
     pub(crate) fn peek_next(&self) -> &Token {
@@ -74,8 +76,37 @@ impl Parser {
     }
 
     /// Parseia um programa C completo: declarações globais até EOF.
-    pub fn parse_program(&mut self) -> Result<Program, Diagnostic> {
+    /// Nunca falha — erros ficam dentro do `Program` retornado.
+    pub fn parse_program(&mut self) -> Program {
         crate::parser::rules::declarations::parse_program(self)
+    }
+
+    /// Recovery para o nível global: avança até ';' ou início de nova declaração de tipo.
+    pub(crate) fn synchronize(&mut self) {
+        while !self.is_at_end() {
+            match self.peek_kind() {
+                TokenKind::Semicolon => { self.advance(); return; }
+                TokenKind::Int | TokenKind::Char | TokenKind::Float
+                | TokenKind::Double | TokenKind::Void
+                | TokenKind::Struct | TokenKind::Const => return,
+                _ => { self.advance(); }
+            }
+        }
+    }
+
+    /// Recovery para o interior de um bloco: avança até ';' ou início de novo statement.
+    pub(crate) fn synchronize_block(&mut self) {
+        while !self.is_at_end() {
+            match self.peek_kind() {
+                TokenKind::Semicolon => { self.advance(); return; }
+                TokenKind::RightBrace | TokenKind::If | TokenKind::While
+                | TokenKind::For | TokenKind::Do | TokenKind::Return
+                | TokenKind::Break | TokenKind::Continue
+                | TokenKind::Int | TokenKind::Char | TokenKind::Float
+                | TokenKind::Double | TokenKind::Void | TokenKind::Const => return,
+                _ => { self.advance(); }
+            }
+        }
     }
 
     /// Retorna o token atual sem avançar a posição.

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -8,12 +8,21 @@ use crate::parser::parser::Parser;
 use crate::parser::rules::declarations::types::parse_type;
 
 /// Parseia um programa C completo: sequência de declarações globais até EOF.
-pub fn parse_program(parser: &mut Parser) -> Result<Program, CompilerError> {
+pub fn parse_program(parser: &mut Parser) -> Program {
     let mut decls = Vec::new();
     while !parser.is_at_end() {
-        decls.push(parse_global_item(parser)?);
+        match parse_global_item(parser) {
+            Ok(decl) => decls.push(decl),
+            Err(e) => {
+                parser.errors.push(e);   // registra o erro
+                parser.synchronize();    // avança até ponto seguro
+            }
+        }
     }
-    Ok(Program { decls })
+    Program {
+        decls,
+        errors: std::mem::take(&mut parser.errors),  // drena os erros para o Program
+    }
 }
 
 /// Dispatcher do escopo global: tipo + lookahead para distinguir função de variável global.

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -35,7 +35,13 @@ pub fn parse_block(parser: &mut Parser) -> Result<Stmt, CompilerError> {
 
     let mut stmts = Vec::new();
     while !parser.check(&TokenKind::RightBrace) && !parser.is_at_end() {
-        stmts.push(parse_stmt(parser)?);
+        match parse_stmt(parser) {
+            Ok(stmt) => stmts.push(stmt),
+            Err(e) => {
+                parser.errors.push(e);
+                parser.synchronize_block();  // avança até próximo statement ou '}'
+            }
+        }
     }
 
     let rbrace = parser

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1093,9 +1093,8 @@ mod tests {
             tk(TokenKind::RightBrace, 28),
             eof(29),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 1);
         let Decl::Function(qty, name, params, body, _) = &program.decls[0] else {
             panic!("esperava Decl::Function");
@@ -1128,9 +1127,8 @@ mod tests {
             tk(TokenKind::RightBrace, 39),
             eof(40),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 1);
         let Decl::Function(_, name, params, body, _) = &program.decls[0] else {
             panic!("esperava Decl::Function");
@@ -1152,9 +1150,8 @@ mod tests {
             tk(TokenKind::RightBrace, 14),
             eof(15),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 1);
         let Decl::Function(qty, name, params, body, _) = &program.decls[0] else {
             panic!("esperava Decl::Function");
@@ -1176,9 +1173,8 @@ mod tests {
             tk(TokenKind::Semicolon, 11),
             eof(12),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 1);
         let Decl::GlobalVar(qty, name, Some(init), _) = &program.decls[0] else {
             panic!("esperava Decl::GlobalVar");
@@ -1197,9 +1193,8 @@ mod tests {
             tk(TokenKind::Semicolon, 8),
             eof(9),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 1);
         let Decl::GlobalVar(qty, name, None, _) = &program.decls[0] else {
             panic!("esperava Decl::GlobalVar");
@@ -1226,9 +1221,8 @@ mod tests {
             tk(TokenKind::RightBrace, 31),
             eof(32),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 2);
         assert!(matches!(
             &program.decls[0],
@@ -1260,9 +1254,8 @@ mod tests {
             tk(TokenKind::RightBrace, 41),
             eof(42),
         ];
-        let program = Parser::new(tokens)
-            .parse_program()
-            .expect("programa válido");
+        let program = Parser::new(tokens).parse_program();
+        assert!(program.errors.is_empty(), "erros inesperados: {:?}", program.errors);
         assert_eq!(program.decls.len(), 1);
         let Decl::Function(_, name, _, body, _) = &program.decls[0] else {
             panic!("esperava Decl::Function");
@@ -1324,5 +1317,81 @@ mod tests {
                 ast
             );
         }
+    }
+    /// Múltiplas declarações inválidas devem produzir >= 2 diagnósticos.
+    #[test]
+    fn recovery_reports_multiple_errors() {
+        // Dois identificadores soltos no escopo global: cada um gera um erro
+        // int ??? int ???
+        let tokens = vec![
+            // primeira declão inválida: "int @ ;"
+            tk(TokenKind::Int, 1),
+            tk(TokenKind::Unknown('@'), 5),
+            tk(TokenKind::Semicolon, 6),
+            // segunda declaração inválida: "int @ ;"
+            tk(TokenKind::Int, 8),
+            tk(TokenKind::Unknown('@'), 12),
+            tk(TokenKind::Semicolon, 13),
+            eof(15),
+        ];
+        let program = Parser::new(tokens).parse_program();
+        assert!(
+            program.errors.len() >= 2,
+            "esperava pelo menos 2 erros, obteve {}: {:?}",
+            program.errors.len(),
+            program.errors
+        );
+    }
+
+    /// Após um erro, uma declaração válida deve ser parseada normalmente.
+    #[test]
+    fn recovery_valid_decl_after_error() {
+        // "int @ ;" seguido de "int x;" válido
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            tk(TokenKind::Unknown('@'), 5),
+            tk(TokenKind::Semicolon, 6),
+            tk(TokenKind::Int, 8),
+            ident("x", 12),
+            tk(TokenKind::Semicolon, 13),
+            eof(14),
+        ];
+        let program = Parser::new(tokens).parse_program();
+        assert_eq!(program.errors.len(), 1, "esperava exatamente 1 erro");
+        assert_eq!(program.decls.len(), 1, "esperava 1 declaração válida após a recovery");
+    }
+
+    /// Um erro dentro de um bloco deve ser coletado e a função deve continuar sendo parseada.
+    #[test]
+    fn recovery_on_missing_semicolon_in_block() {
+        // int f() { int x = 1   return 0; }   <- falta ';' após x = 1
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            ident("f", 5),
+            tk(TokenKind::LeftParen, 6),
+            tk(TokenKind::RightParen, 7),
+            tk(TokenKind::LeftBrace, 9),
+            // int x = 1   <- sem ';'
+            tk(TokenKind::Int, 11),
+            ident("x", 15),
+            tk(TokenKind::Equal, 17),
+            int(1, 19),
+            // return 0;
+            tk(TokenKind::Return, 21),
+            int(0, 28),
+            tk(TokenKind::Semicolon, 29),
+            tk(TokenKind::RightBrace, 31),
+            eof(32),
+        ];
+        let program = Parser::new(tokens).parse_program();
+        assert!(
+            !program.errors.is_empty(),
+            "esperava pelo menos 1 erro (';' ausente)"
+        );
+        assert_eq!(
+            program.decls.len(),
+            1,
+            "a função deve ter sido parseada mesmo com o erro no bloco"
+        );
     }
 }


### PR DESCRIPTION
## Motivação

O parser parava no **primeiro erro sintático** e retornava imediatamente,
forçando ciclos de corrigir → compilar → corrigir. As issues #74 e #100
pediam que **N erros produzam N diagnósticos** na mesma passagem.

## Estratégia

Implementado o clássico **panic-mode recovery**: ao encontrar um erro,
registra o diagnóstico, avança os tokens até um ponto seguro
(_synchronization point_) e retoma o parse normalmente.

## Mudanças

### `common/ast/ast.rs`
- `Program` agora carrega `pub errors: Vec<CompilerError>` junto com as
  declarações parseadas com sucesso.
- Removidos `Clone` e `PartialEq` de `Program` (`CompilerError` não os
  implementa).

### `parser/parser.rs`
- Adicionado campo `pub errors: Vec<CompilerError>` ao `Parser`.
- `parse_program` passa a retornar `Program` diretamente (sem `Result`) —
  erros vivem dentro do `Program`.
- Adicionados dois métodos de sincronização:
  - `synchronize()` — para o nível global: avança até `;` ou keyword de tipo.
  - `synchronize_block()` — para interior de bloco: avança até `;`, `}` ou
    keyword de statement.

### `declarations/top_level.rs`
- `parse_program` convertido de **fail-fast** para **error-collecting**:
  usa `match` + `parser.synchronize()` em vez de `?`.
- Erros são drenados para `Program` via `std::mem::take`.

### `statements/basic.rs`
- `parse_block` convertido para resiliente: usa `match` +
  `parser.synchronize_block()` em vez de `?`.
- Um erro num statement não mata o parse do bloco inteiro.

### `main.rs`
- Adaptado ao novo retorno de `parse_program`: imprime **todos** os erros
  acumulados antes de encerrar (antes, apenas o primeiro era exibido).

### `tests/parser_test.rs`
- 7 testes de `parse_program` atualizados para a nova assinatura sem `Result`.
- 3 novos testes de recovery adicionados:
  - `recovery_reports_multiple_errors` — múltiplos erros geram ≥ 2 diagnósticos.
  - `recovery_valid_decl_after_error` — declaração válida é parseada após um erro.
  - `recovery_on_missing_semicolon_in_block` — erro no bloco é coletado e a
    função continua sendo parseada.

## Resultado

```
test tests::parser_test::tests::recovery_on_missing_semicolon_in_block ... ok
test tests::parser_test::tests::recovery_reports_multiple_errors ... ok
test tests::parser_test::tests::recovery_valid_decl_after_error ... ok
```

---

Closes #74 
Closes #100 