### PR TITLE
fix: add struct declaration parsing and related tests

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -29,6 +29,11 @@ impl Parser {
         &self.tokens[next]
     }
 
+    pub(crate) fn peek_at(&self, offset: usize) -> &Token {
+        let idx = (self.pos + offset).min(self.tokens.len() - 1);
+        &self.tokens[idx]
+    }
+
     /// Parseia uma expressão com precedência mínima `min_bp` usando o algoritmo Pratt (top-down operator precedence).
     /// Retorna a expressão construída ou um `Diagnostic` de erro sintático.
     pub fn parse_expr(&mut self, min_bp: u8) -> Result<Expr, Diagnostic> {

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -120,7 +120,11 @@ fn parse_struct_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
 
     let name_token = parser.advance().clone();
     let TokenKind::Identifier(name) = name_token.kind else {
-        return Err(parser.syntax_error(&name_token, "nome da struct", &format!("{:?}", name_token.kind)));
+        return Err(parser.syntax_error(
+            &name_token,
+            "nome da struct",
+            &format!("{:?}", name_token.kind),
+        ));
     };
 
     parser.expect(&TokenKind::LeftBrace, "'{' após nome da struct")?;
@@ -140,7 +144,9 @@ fn parse_struct_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
         fields.push((field_type, field_name));
     }
 
-    let end = parser.expect(&TokenKind::RightBrace, "'}' ao fim da struct")?.clone();
+    let end = parser
+        .expect(&TokenKind::RightBrace, "'}' ao fim da struct")?
+        .clone();
     parser.expect(&TokenKind::Semicolon, "';' após definição de struct")?;
 
     let span = parser.join_span(parser.span_of(&start), parser.span_of(&end));

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -30,6 +30,14 @@ pub fn parse_program(parser: &mut Parser) -> Result<Program, Vec<CompilerError>>
 /// Dispatcher do escopo global: tipo + lookahead para distinguir função de variável global.
 fn parse_global_item(parser: &mut Parser) -> Result<Decl, CompilerError> {
     let start = parser.peek().clone();
+
+    if parser.check(&TokenKind::Struct)
+        && matches!(parser.peek_at(1).kind, TokenKind::Identifier(_))
+        && parser.peek_at(2).kind == TokenKind::LeftBrace
+    {
+        return parse_struct_decl(parser);
+    }
+
     let qty = parse_type(parser)?;
 
     let name_token = parser.advance().clone();
@@ -104,6 +112,39 @@ fn parse_param(parser: &mut Parser) -> Result<(QualifierType, String), CompilerE
         ));
     };
     Ok((qty, name))
+}
+
+/// Parseia uma definição de struct: `struct Name { type field; ... };`
+fn parse_struct_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
+    let start = parser.advance().clone(); // consome 'struct'
+
+    let name_token = parser.advance().clone();
+    let TokenKind::Identifier(name) = name_token.kind else {
+        return Err(parser.syntax_error(&name_token, "nome da struct", &format!("{:?}", name_token.kind)));
+    };
+
+    parser.expect(&TokenKind::LeftBrace, "'{' após nome da struct")?;
+
+    let mut fields = Vec::new();
+    while !parser.check(&TokenKind::RightBrace) && !parser.is_at_end() {
+        let field_type = parse_type(parser)?;
+        let field_name_token = parser.advance().clone();
+        let TokenKind::Identifier(field_name) = field_name_token.kind else {
+            return Err(parser.syntax_error(
+                &field_name_token,
+                "nome do campo",
+                &format!("{:?}", field_name_token.kind),
+            ));
+        };
+        parser.expect(&TokenKind::Semicolon, "';' após campo da struct")?;
+        fields.push((field_type, field_name));
+    }
+
+    let end = parser.expect(&TokenKind::RightBrace, "'}' ao fim da struct")?.clone();
+    parser.expect(&TokenKind::Semicolon, "';' após definição de struct")?;
+
+    let span = parser.join_span(parser.span_of(&start), parser.span_of(&end));
+    Ok(Decl::StructDecl(name, fields, span))
 }
 
 /// Continua o parsing de uma variável global após tipo e nome: `(= expr)? ;`.

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1481,4 +1481,115 @@ mod tests {
             assert_eq!(op, expected_op, "BinOp errado para {:?}", token_kind);
         }
     }
+
+    // ── struct ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_struct_decl_with_fields() {
+        // struct Point { int x; int y; };
+        let tokens = vec![
+            tk(TokenKind::Struct, 1),
+            ident("Point", 8),
+            tk(TokenKind::LeftBrace, 14),
+            tk(TokenKind::Int, 16),
+            ident("x", 20),
+            tk(TokenKind::Semicolon, 21),
+            tk(TokenKind::Int, 23),
+            ident("y", 27),
+            tk(TokenKind::Semicolon, 28),
+            tk(TokenKind::RightBrace, 30),
+            tk(TokenKind::Semicolon, 31),
+            eof(32),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear struct com campos");
+        assert_eq!(prog.decls.len(), 1);
+        let Decl::StructDecl(name, fields, _) = &prog.decls[0] else {
+            panic!("esperava Decl::StructDecl");
+        };
+        assert_eq!(name, "Point");
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].1, "x");
+        assert_eq!(fields[0].0.ty, Type::Int);
+        assert_eq!(fields[1].1, "y");
+        assert_eq!(fields[1].0.ty, Type::Int);
+    }
+
+    #[test]
+    fn parses_struct_decl_empty_body() {
+        // struct Empty {};
+        let tokens = vec![
+            tk(TokenKind::Struct, 1),
+            ident("Empty", 8),
+            tk(TokenKind::LeftBrace, 14),
+            tk(TokenKind::RightBrace, 15),
+            tk(TokenKind::Semicolon, 16),
+            eof(17),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear struct vazia");
+        let Decl::StructDecl(name, fields, _) = &prog.decls[0] else {
+            panic!("esperava Decl::StructDecl");
+        };
+        assert_eq!(name, "Empty");
+        assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn parses_struct_decl_with_pointer_field() {
+        // struct Node { int val; struct Node *next; };
+        let tokens = vec![
+            tk(TokenKind::Struct, 1),
+            ident("Node", 8),
+            tk(TokenKind::LeftBrace, 13),
+            tk(TokenKind::Int, 15),
+            ident("val", 19),
+            tk(TokenKind::Semicolon, 22),
+            tk(TokenKind::Struct, 24),
+            ident("Node", 31),
+            tk(TokenKind::Star, 36),
+            ident("next", 37),
+            tk(TokenKind::Semicolon, 41),
+            tk(TokenKind::RightBrace, 43),
+            tk(TokenKind::Semicolon, 44),
+            eof(45),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser
+            .parse_program()
+            .expect("deve parsear struct com campo ponteiro");
+        let Decl::StructDecl(name, fields, _) = &prog.decls[0] else {
+            panic!("esperava Decl::StructDecl");
+        };
+        assert_eq!(name, "Node");
+        assert_eq!(fields.len(), 2);
+        assert!(matches!(fields[1].0.ty, Type::Pointer(_)));
+    }
+
+    #[test]
+    fn parses_struct_use_as_type_after_definition() {
+        // struct Point { int x; }; struct Point p;
+        let tokens = vec![
+            tk(TokenKind::Struct, 1),
+            ident("Point", 8),
+            tk(TokenKind::LeftBrace, 14),
+            tk(TokenKind::Int, 16),
+            ident("x", 20),
+            tk(TokenKind::Semicolon, 21),
+            tk(TokenKind::RightBrace, 23),
+            tk(TokenKind::Semicolon, 24),
+            tk(TokenKind::Struct, 26),
+            ident("Point", 33),
+            ident("p", 39),
+            tk(TokenKind::Semicolon, 40),
+            eof(41),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser
+            .parse_program()
+            .expect("deve parsear definição seguida de uso de struct");
+        assert_eq!(prog.decls.len(), 2);
+        assert!(matches!(prog.decls[0], Decl::StructDecl(_, _, _)));
+        assert!(matches!(prog.decls[1], Decl::GlobalVar(_, _, _, _)));
+    }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1502,7 +1502,9 @@ mod tests {
             eof(32),
         ];
         let mut parser = Parser::new(tokens);
-        let prog = parser.parse_program().expect("deve parsear struct com campos");
+        let prog = parser
+            .parse_program()
+            .expect("deve parsear struct com campos");
         assert_eq!(prog.decls.len(), 1);
         let Decl::StructDecl(name, fields, _) = &prog.decls[0] else {
             panic!("esperava Decl::StructDecl");


### PR DESCRIPTION
This pull request adds support for parsing C-style `struct` definitions in the parser, including the ability to handle fields (including pointer fields) and empty structs. It also introduces comprehensive tests to ensure correct parsing of various struct declaration scenarios.

**Parser enhancements:**
* Added a new method `peek_at` to the `Parser` for flexible lookahead during parsing.
* Updated the global item dispatcher to recognize and correctly dispatch `struct` declarations.
* Implemented the `parse_struct_decl` function to parse struct definitions, including field types and names, and integrate them as `Decl::StructDecl` in the AST.

**Testing improvements:**
* Added multiple tests to verify parsing of struct declarations, including structs with fields, empty structs, structs with pointer fields, and usage of structs as types after their definition.

closes #107 