### PR TITLE
feat: add array declaration parsing support

### DIFF
--- a/src/parser/rules/declarations/mod.rs
+++ b/src/parser/rules/declarations/mod.rs
@@ -3,5 +3,5 @@ pub mod types;
 pub mod var_decl;
 
 pub use top_level::parse_program;
-pub use types::{parse_type, starts_type};
+pub use types::{parse_array_suffix, parse_type, starts_type};
 pub use var_decl::parse_var_decl;

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -5,7 +5,7 @@ use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token::Token;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
-use crate::parser::rules::declarations::types::parse_type;
+use crate::parser::rules::declarations::types::{parse_array_suffix, parse_type};
 
 /// Parseia um programa C completo: sequência de declarações globais até EOF.
 /// Ao encontrar erro, sincroniza no próximo `;` ou `}` e continua, acumulando todos os erros.
@@ -106,13 +106,15 @@ fn parse_param(parser: &mut Parser) -> Result<(QualifierType, String), CompilerE
     Ok((qty, name))
 }
 
-/// Continua o parsing de uma variável global após tipo e nome: `(= expr)? ;`.
+/// Continua o parsing de uma variável global após tipo e nome: `([N])? (= expr)? ;`.
 pub(crate) fn parse_global_var_decl(
     parser: &mut Parser,
     qty: QualifierType,
     name: String,
     start: Token,
 ) -> Result<Decl, CompilerError> {
+    let qty = parse_array_suffix(parser, qty)?;
+
     let init = if parser.match_kind(&TokenKind::Equal) {
         Some(parser.parse_expr(0)?)
     } else {

--- a/src/parser/rules/declarations/types.rs
+++ b/src/parser/rules/declarations/types.rs
@@ -3,6 +3,24 @@ use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
 
+/// Consome sufixos `[expr?]` após o nome de uma variável e envolve o tipo em `Type::Array`.
+/// Suporta múltiplas dimensões: `int arr[3][4]` → `Array(Array(Int))`.
+/// O tamanho é consumido mas não armazenado (AST atual não possui campo de tamanho).
+pub fn parse_array_suffix(
+    parser: &mut Parser,
+    mut qty: QualifierType,
+) -> Result<QualifierType, CompilerError> {
+    while parser.check(&TokenKind::LeftBracket) {
+        parser.advance();
+        if !parser.check(&TokenKind::RightBracket) {
+            parser.parse_expr(0)?;
+        }
+        parser.expect(&TokenKind::RightBracket, "']' ao fim do tamanho do array")?;
+        qty.ty = Type::Array(Box::new(qty.ty));
+    }
+    Ok(qty)
+}
+
 // Retorna `true` se o token inicia uma declaração de tipo
 pub fn starts_type(kind: &TokenKind) -> bool {
     matches!(

--- a/src/parser/rules/declarations/var_decl.rs
+++ b/src/parser/rules/declarations/var_decl.rs
@@ -2,7 +2,7 @@ use crate::common::ast::stmt::Stmt;
 use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
-use crate::parser::rules::declarations::types::parse_type;
+use crate::parser::rules::declarations::types::{parse_array_suffix, parse_type};
 
 /// Parseia uma declaração de variável local: `tipo ident (= expr)? ;`
 /// Pressupõe que o token atual já foi confirmado como keyword de tipo.
@@ -20,6 +20,8 @@ pub fn parse_var_decl(parser: &mut Parser) -> Result<Stmt, CompilerError> {
             &format!("{:?}", name_token.kind),
         ));
     };
+
+    let qty = parse_array_suffix(parser, qty)?;
 
     // Inicializador Opcional: = expr
     let init = if parser.match_kind(&TokenKind::Equal) {

--- a/src/parser/rules/declarations/var_decl.rs
+++ b/src/parser/rules/declarations/var_decl.rs
@@ -4,7 +4,7 @@ use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
 use crate::parser::rules::declarations::types::{parse_array_suffix, parse_type};
 
-/// Parseia uma declaração de variável local: `tipo ident (= expr)? ;`
+/// Parseia uma declaração de variável local: `tipo ident ([expr?])* (= expr)? ;`
 /// Pressupõe que o token atual já foi confirmado como keyword de tipo.
 pub fn parse_var_decl(parser: &mut Parser) -> Result<Stmt, CompilerError> {
     let start = parser.peek().clone();

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1481,4 +1481,104 @@ mod tests {
             assert_eq!(op, expected_op, "BinOp errado para {:?}", token_kind);
         }
     }
+
+    // ── arrays ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_global_array_declaration() {
+        // int arr[10];
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            ident("arr", 5),
+            tk(TokenKind::LeftBracket, 8),
+            tk(TokenKind::IntLiteral(10), 9),
+            tk(TokenKind::RightBracket, 11),
+            tk(TokenKind::Semicolon, 12),
+            eof(13),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear array global");
+        let Decl::GlobalVar(qty, name, None, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        assert_eq!(name, "arr");
+        assert!(matches!(qty.ty, Type::Array(_)));
+    }
+
+    #[test]
+    fn parses_local_array_declaration() {
+        // void f() { int arr[5]; }
+        let tokens = vec![
+            tk(TokenKind::Void, 1),
+            ident("f", 6),
+            tk(TokenKind::LeftParen, 7),
+            tk(TokenKind::RightParen, 8),
+            tk(TokenKind::LeftBrace, 10),
+            tk(TokenKind::Int, 12),
+            ident("arr", 16),
+            tk(TokenKind::LeftBracket, 19),
+            tk(TokenKind::IntLiteral(5), 20),
+            tk(TokenKind::RightBracket, 21),
+            tk(TokenKind::Semicolon, 22),
+            tk(TokenKind::RightBrace, 24),
+            eof(25),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear array local");
+        let Decl::Function(_, _, _, body, _) = &prog.decls[0] else {
+            panic!("esperava Function");
+        };
+        let Stmt::VarDecl(qty, name, None, _) = &body[0] else {
+            panic!("esperava VarDecl");
+        };
+        assert_eq!(name, "arr");
+        assert!(matches!(qty.ty, Type::Array(_)));
+    }
+
+    #[test]
+    fn parses_multidimensional_array() {
+        // int matrix[3][4];
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            ident("matrix", 5),
+            tk(TokenKind::LeftBracket, 11),
+            tk(TokenKind::IntLiteral(3), 12),
+            tk(TokenKind::RightBracket, 13),
+            tk(TokenKind::LeftBracket, 14),
+            tk(TokenKind::IntLiteral(4), 15),
+            tk(TokenKind::RightBracket, 16),
+            tk(TokenKind::Semicolon, 17),
+            eof(18),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear array 2D");
+        let Decl::GlobalVar(qty, _, None, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        let Type::Array(inner) = &qty.ty else {
+            panic!("esperava Array externo");
+        };
+        assert!(matches!(**inner, Type::Array(_)));
+    }
+
+    #[test]
+    fn parses_array_without_size() {
+        // int arr[];
+        let tokens = vec![
+            tk(TokenKind::Int, 1),
+            ident("arr", 5),
+            tk(TokenKind::LeftBracket, 8),
+            tk(TokenKind::RightBracket, 9),
+            tk(TokenKind::Semicolon, 10),
+            eof(11),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser
+            .parse_program()
+            .expect("deve parsear array sem tamanho");
+        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        assert!(matches!(qty.ty, Type::Array(_)));
+    }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1571,14 +1571,15 @@ mod tests {
             tk(TokenKind::RightBracket, 9),
             tk(TokenKind::Semicolon, 10),
             eof(11),
-          ];
+        ];
         let mut parser = Parser::new(tokens);
         let prog = parser
             .parse_program()
-            .expect("deve parsear definição seguida de uso de struct");
-        assert_eq!(prog.decls.len(), 2);
-        assert!(matches!(prog.decls[0], Decl::StructDecl(_, _, _)));
-        assert!(matches!(prog.decls[1], Decl::GlobalVar(_, _, _, _)));
+            .expect("deve parsear array sem tamanho");
+        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        assert!(matches!(qty.ty, Type::Array(_)));
     }
     // ── struct ────────────────────────────────────────────────────────────────
 
@@ -1683,10 +1684,13 @@ mod tests {
             ident("p", 39),
             tk(TokenKind::Semicolon, 40),
             eof(41),
-            .expect("deve parsear array sem tamanho");
-        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
-            panic!("esperava GlobalVar");
-        };
-        assert!(matches!(qty.ty, Type::Array(_)));
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser
+            .parse_program()
+            .expect("deve parsear definição seguida de uso de struct");
+        assert_eq!(prog.decls.len(), 2);
+        assert!(matches!(prog.decls[0], Decl::StructDecl(_, _, _)));
+        assert!(matches!(prog.decls[1], Decl::GlobalVar(_, _, _, _)));
     }
 }


### PR DESCRIPTION
This pull request adds support for parsing array types in both global and local variable declarations, including multidimensional arrays and arrays without specified sizes. It introduces a new helper function to handle array suffixes in type declarations, updates the parsing logic to use this function, and adds comprehensive tests to ensure correct parsing of various array scenarios.

**Parser enhancements for array types:**

* Added the `parse_array_suffix` function in `types.rs` to consume array suffixes (`[N]`) after variable names, supporting multiple dimensions and arrays without specified sizes. The parsed type is wrapped in `Type::Array`, though the size is not stored in the AST.
* Updated both global (`top_level.rs`) and local (`var_decl.rs`) variable declaration parsers to use `parse_array_suffix`, enabling consistent array type handling across declaration contexts. 

**API and module changes:**

* Re-exported `parse_array_suffix` from the `types` module for use in other parser components.
* Updated imports in affected files to include `parse_array_suffix`.
**Testing improvements:**

* Added new tests to `parser_test.rs` covering global and local array declarations, multidimensional arrays, and arrays without a specified size to verify correct parsing behavior.

Closes #108 