### PR TITLE
feat(parser): add long and short as recognized types

### DIFF
--- a/src/common/ast/ast.rs
+++ b/src/common/ast/ast.rs
@@ -4,12 +4,14 @@ use crate::common::ast::decl::Decl;
 pub enum Type {
     // Só armazena, então o que importa é a capacidade.
     Int,
+    Long,
+    Short,
     Char,
     Float,
     Double,
     Void,
-    Array(Box<Type>),   //Determinar os tipos de arrays
-    Pointer(Box<Type>), // olhar onde pode usar
+    Array(Box<Type>),
+    Pointer(Box<Type>),
     Struct(String),
 }
 

--- a/src/parser/rules/declarations/types.rs
+++ b/src/parser/rules/declarations/types.rs
@@ -28,6 +28,8 @@ pub fn starts_type(kind: &TokenKind) -> bool {
         TokenKind::Const
             | TokenKind::Unsigned
             | TokenKind::Int
+            | TokenKind::Long
+            | TokenKind::Short
             | TokenKind::Float
             | TokenKind::Double
             | TokenKind::Struct
@@ -56,6 +58,14 @@ pub fn parse_type(parser: &mut Parser) -> Result<QualifierType, CompilerError> {
         TokenKind::Int => {
             parser.advance();
             Type::Int
+        }
+        TokenKind::Long => {
+            parser.advance();
+            Type::Long
+        }
+        TokenKind::Short => {
+            parser.advance();
+            Type::Short
         }
         TokenKind::Char => {
             parser.advance();

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1693,4 +1693,80 @@ mod tests {
         assert!(matches!(prog.decls[0], Decl::StructDecl(_, _, _)));
         assert!(matches!(prog.decls[1], Decl::GlobalVar(_, _, _, _)));
     }
+
+    // ── long / short ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_long_variable() {
+        // long x;
+        let tokens = vec![
+            tk(TokenKind::Long, 1),
+            ident("x", 6),
+            tk(TokenKind::Semicolon, 7),
+            eof(8),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear long");
+        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        assert!(matches!(qty.ty, Type::Long));
+    }
+
+    #[test]
+    fn parses_short_variable() {
+        // short y;
+        let tokens = vec![
+            tk(TokenKind::Short, 1),
+            ident("y", 7),
+            tk(TokenKind::Semicolon, 8),
+            eof(9),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear short");
+        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        assert!(matches!(qty.ty, Type::Short));
+    }
+
+    #[test]
+    fn parses_unsigned_long_variable() {
+        // unsigned long z;
+        let tokens = vec![
+            tk(TokenKind::Unsigned, 1),
+            tk(TokenKind::Long, 10),
+            ident("z", 15),
+            tk(TokenKind::Semicolon, 16),
+            eof(17),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear unsigned long");
+        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        assert!(matches!(qty.ty, Type::Long));
+        assert!(qty.is_unsigned);
+    }
+
+    #[test]
+    fn parses_long_pointer() {
+        // long *p;
+        let tokens = vec![
+            tk(TokenKind::Long, 1),
+            tk(TokenKind::Star, 6),
+            ident("p", 7),
+            tk(TokenKind::Semicolon, 8),
+            eof(9),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear long*");
+        let Decl::GlobalVar(qty, _, _, _) = &prog.decls[0] else {
+            panic!("esperava GlobalVar");
+        };
+        let Type::Pointer(inner) = &qty.ty else {
+            panic!("esperava Pointer");
+        };
+        assert!(matches!(**inner, Type::Long));
+    }
 }


### PR DESCRIPTION
This pull request adds support for the `long` and `short` types in the language's type system and parser, along with corresponding parser tests to ensure correct handling. The changes update both the AST and parsing logic to recognize and process these types.

Type system and parsing updates:
* Added `Long` and `Short` variants to the `Type` enum in `src/common/ast/ast.rs` to represent these types in the AST.
* Updated the `starts_type` and `parse_type` functions in `src/parser/rules/declarations/types.rs` to recognize and correctly parse `long` and `short` tokens as types. 
Testing:
* Added tests in `src/tests/parser_test.rs` to verify parsing of `long`, `short`, `unsigned long`, and pointer-to-long variable declarations.

Closes #109 