### PR TITLE
feat(docs): add lexer and parser documentation

### DIFF
--- a/docs/lexer.md
+++ b/docs/lexer.md
@@ -1,0 +1,192 @@
+# Lexer
+
+## Visão Geral
+
+O lexer transforma o código-fonte em uma sequência de tokens. A entrada é um `SourceFile` — que pode ser um arquivo em disco ou uma string (usado nos testes) — e a saída é `Vec<Token>`, mais um vetor de diagnósticos acumulados em caso de erros.
+
+O ponto de entrada é `Scanner::scan()`, que processa o arquivo inteiro antes de retornar. Erros léxicos não interrompem o processo: são acumulados e o scanner continua tentando produzir mais tokens.
+
+---
+
+## Leitura Caracter a Caracter
+
+O `SourceFile` expõe uma API de cursor:
+
+- `peek()` — lê o próximo char sem avançar
+- `peek_ahead()` — lê o char em +2 sem avançar (usado para lookahead duplo)
+- `advance()` — consome o char atual e atualiza a posição
+- `advance_if(predicate)` — consome somente se o predicado for verdadeiro
+
+Internamente o `SourceFile` rastreia três campos:
+
+| Campo | Descrição |
+|---|---|
+| `pos: usize` | offset em bytes no arquivo |
+| `line: usize` | linha atual (começa em 1, incrementa a cada `\n`) |
+| `col: usize` | coluna atual (começa em 1, reseta em `\n`) |
+
+---
+
+## Fluxo do Scanner
+
+`scan()` é um loop que repete `next_token()` até o EOF. A cada iteração:
+
+1. Espaços e comentários são descartados por `skip_whitespaces_and_comments()`
+2. `token_start` é capturado — byte offset do início do token
+3. O primeiro char é consumido e o scanner despacha para a regra correspondente:
+
+```
+char → handler
+─────────────────────────────────
+0–9         → lex_number()
+" "         → lex_string()
+' '         → lex_char()
+a–z, A–Z, _ → lex_identifier()
+operadores  → lex_operator()
+delimitadores → push token simples + rastreia na delimiter_stack
+outros      → emit_unknown()
+```
+
+---
+
+## Rastreamento de Spans
+
+Cada token armazena dois tipos de posição:
+
+- `ByteSpan { start, end }` — offsets brutos em bytes (para fatiar o source)
+- `line` e `col` — linha e coluna do início do token (para relatórios de erro)
+
+O `Span` usado nos diagnósticos é derivado depois: `{ line, end_line, column_start, column_end }`.
+
+---
+
+## Comentários e Diretivas de Pré-processador
+
+Tratados em `skip_whitespaces_and_comments()` antes de qualquer token ser produzido:
+
+- `// ...` — consumido até `\n`
+- `/* ... */` — consumido até `*/`; se o EOF chegar sem fechar, emite `UnclosedBlockComment`
+- `# ...` — diretivas de pré-processador são consumidas até `\n` e **descartadas** completamente (nenhum token é produzido)
+
+---
+
+## Delimitadores Balanceados
+
+O scanner mantém uma `delimiter_stack: Vec<(char, linha, coluna)>`. A cada `(`, `[` ou `{` empilha; a cada `)`, `]` ou `}` desempilha e verifica se o par bate.
+
+| Situação | Erro emitido |
+|---|---|
+| Fechar sem abrir | `UnexpectedClosingDelimiter(char)` |
+| EOF com pilha não vazia | `UnclosedDelimiter(char)` |
+
+Os tokens ainda são produzidos normalmente — o erro é diagnóstico, não fatal.
+
+---
+
+## Literais Numéricos
+
+A função `lex_number()` decide o formato pelo prefixo:
+
+| Prefixo | Formato | Conversão |
+|---|---|---|
+| `0x` / `0X` | Hexadecimal | `i64::from_str_radix(&buf[2..], 16)` |
+| `0` + dígitos | Octal | `i64::from_str_radix(&buf[1..], 8)` |
+| Sem prefixo | Decimal | `buf.parse::<i64>()` |
+
+Se um dígito octal inválido (8 ou 9) for encontrado, emite `InvalidOctalDigit(c)`.
+
+**Ponto flutuante:** detectado pela presença de `.` ou `e`/`E` durante o consumo. A fração e o expoente (com `+`/`-` opcional) são acumulados na mesma string e convertidos com `buf.parse::<f64>()`.
+
+**Sufixos** (`u`, `U`, `l`, `L` para inteiros; `f`, `F` para floats) são consumidos e descartados — o AST não distingue por sufixo neste estágio.
+
+---
+
+## Literais de String e Char
+
+**String** (`lex_string()`):
+- Delimitada por `"`
+- Sequências de escape suportadas: `\n`, `\t`, `\r`, `\\`, `\"`, `\'`, `\0`
+- Se encontrar `\n` ou EOF antes do `"` de fechamento → `UnterminatedLiteral`
+- Armazenada já com escapes resolvidos: `StringLiteral(String)`
+
+**Char** (`lex_char()`):
+- Delimitado por `'`
+- Aceita um único char ou uma escape sequence
+- Armazenado como `CharLiteral(char)`
+
+---
+
+## Identificadores e Keywords
+
+`lex_identifier()` consome enquanto o char satisfazer `is_ident_continue()` (letras, dígitos, `_`). Em seguida consulta `lookup_keyword()`:
+
+- Se a string for uma keyword conhecida → token de keyword (`If`, `Int`, `While`, etc.)
+- Caso contrário → `Identifier(String)`
+
+Keywords reconhecidas: `if`, `else`, `while`, `for`, `do`, `switch`, `case`, `default`, `break`, `continue`, `return`, `int`, `char`, `float`, `double`, `void`, `struct`, `enum`, `union`, `typedef`, `const`, `static`, `extern`, `auto`, `register`, `signed`, `unsigned`, `short`, `long`, `volatile`, `inline`, `sizeof`.
+
+---
+
+## Operadores (Lookahead de 1)
+
+`lex_operator()` usa `peek()` para decidir entre tokens de 1 e 2 (ou 3) chars:
+
+```
+'+'  → peek '+'  → PlusPlus
+     → peek '='  → PlusEqual
+     → PlusPlus  → Plus
+
+'-'  → peek '-'  → MinusMinus
+     → peek '='  → MinusEqual
+     → peek '>'  → Arrow
+     → Minus
+
+'<'  → peek '<'  → peek '='  → LessLessEqual
+               → LessLess
+     → peek '='  → LessEqual
+     → Less
+```
+
+O mesmo padrão se aplica a `>`, `=`, `!`, `&`, `|`, `^`, `*`, `/`, `%`.
+
+---
+
+## Categorias de Tokens
+
+```
+TokenKind
+├── Keywords de controle: If, Else, While, For, Do, Switch, Case, Default,
+│                         Break, Continue, Return
+├── Keywords de tipo:     Int, Long, Short, Char, Float, Double, Void, Struct,
+│                         Enum, Union, Unsigned, Signed, Const, Typedef,
+│                         Static, Extern, Auto, Register, Volatile, Inline
+├── Operadores:           Plus, Minus, Star, Slash, Percent, PlusPlus,
+│                         MinusMinus, PlusEqual, MinusEqual, ... (compostos)
+│                         EqualEqual, BangEqual, Less, Greater, LessEqual,
+│                         GreaterEqual, AndAnd, OrOr, Bang, Ampersand, Pipe,
+│                         Caret, Tilde, LessLess, GreaterGreater, Arrow,
+│                         Sizeof, Question, ...
+├── Delimitadores:        LeftParen, RightParen, LeftBrace, RightBrace,
+│                         LeftBracket, RightBracket, Semicolon, Comma,
+│                         Colon, Dot
+├── Literais:             IntLiteral(i64), FloatLiteral(f64),
+│                         StringLiteral(String), CharLiteral(char)
+├── Identificador:        Identifier(String)
+├── Erro:                 Unknown(char)
+└── Fim:                  Eof
+```
+
+---
+
+## Erros Léxicos
+
+Todos são do tipo `CompilerError::Lexical(LexicalError { span, kind })`:
+
+| Kind | Causa |
+|---|---|
+| `InvalidChar(char)` | Char que não inicia nenhum token válido |
+| `UnclosedBlockComment` | EOF dentro de `/* ... */` |
+| `UnclosedDelimiter(char)` | EOF com `(`, `[` ou `{` sem fechar |
+| `UnexpectedClosingDelimiter(char)` | `)`, `]` ou `}` sem correspondente |
+| `UnterminatedLiteral(String)` | String ou char sem fechar |
+| `InvalidOctalDigit(char)` | Dígito 8 ou 9 em literal octal |

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,356 @@
+# Parser
+
+## Visão Geral
+
+O parser consome a sequência de tokens produzida pelo lexer e constrói uma AST (Abstract Syntax Tree). A entrada é `Vec<Token>` e a saída é `Result<Program, Vec<CompilerError>>`.
+
+O `Program` é simplesmente `Vec<Decl>` — uma lista de declarações globais. Erros sintáticos são acumulados: ao encontrar um erro, o parser sincroniza no próximo ponto seguro e continua tentando parsear o restante do arquivo.
+
+---
+
+## Estrutura do Parser
+
+```rust
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+    diagnostics: Vec<CompilerError>,
+}
+```
+
+API interna:
+
+| Método | Comportamento |
+|---|---|
+| `peek()` | Token atual sem avançar |
+| `peek_kind()` | `TokenKind` do token atual |
+| `peek_at(n)` | Token em `pos + n` sem avançar (lookahead arbitrário) |
+| `peek_next()` | Atalho para `peek_at(1)` |
+| `advance()` | Consome token atual, retorna referência |
+| `check(kind)` | `true` se discriminante bate (ignora payload) |
+| `match_kind(kind)` | Consome e retorna `true` se bate, senão `false` |
+| `expect(kind, msg)` | Consome ou emite `SyntaxError` com `expected` e `found` |
+| `is_at_end()` | `true` se token atual é `Eof` |
+
+---
+
+## Recuperação de Erros
+
+Quando `parse_global_item()` falha, o erro é empurrado para `diagnostics` e `synchronize()` é chamado. A sincronização avança tokens descartando tudo até encontrar `;` ou `}` (consumindo o delimitador), e então tenta o próximo item global.
+
+Isso permite que um arquivo com múltiplos erros produza todos os diagnósticos de uma vez, em vez de parar no primeiro.
+
+---
+
+## Hierarquia de Parse
+
+```
+parse_program()
+└── parse_global_item()          ← loop até EOF
+    ├── parse_struct_decl()      ← se: struct Name {
+    ├── parse_function_decl()    ← se: tipo nome (
+    └── parse_global_var_decl()  ← senão: variável global
+
+parse_function_decl()
+└── parse_block()
+    └── parse_stmt()             ← loop até }
+        ├── parse_var_decl()
+        ├── parse_block()        ← recursivo
+        ├── if / while / for / do-while / switch
+        ├── return / break / continue
+        └── parse_expr() + ;
+
+parse_expr(min_bp)               ← Pratt parser
+├── parse_prefix_expr()
+└── loop:
+    ├── try_parse_postfix()
+    └── infix com binding power
+```
+
+---
+
+## Declarações Globais
+
+### Dispatcher (`parse_global_item`)
+
+O dispatcher usa lookahead para decidir o tipo de declaração sem consumir tokens:
+
+```
+peek[0] == Struct
+  && peek[1] == Identifier
+  && peek[2] == LeftBrace      →  parse_struct_decl()
+
+senão: parse_type() + nome
+  peek == LeftParen             →  parse_function_decl()
+  senão                         →  parse_global_var_decl()
+```
+
+O lookahead de 2 tokens para struct (via `peek_at(2)`) é necessário para distinguir `struct Point { ... }` (definição) de `struct Point p` (uso como tipo).
+
+### Struct (`parse_struct_decl`)
+
+```
+struct Nome {
+    tipo campo;
+    tipo campo;
+    ...
+};
+```
+
+Produz `Decl::StructDecl(nome, Vec<(QualifierType, String)>, span)`.
+
+### Função (`parse_function_decl`)
+
+```
+tipo nome ( [void | tipo param (, tipo param)*] ) { corpo }
+```
+
+Parâmetros `void` são tratados como lista vazia. Produz `Decl::Function(retorno, nome, params, stmts, span)`.
+
+### Variável Global (`parse_global_var_decl`)
+
+```
+tipo nome [N]* [= expr] ;
+```
+
+Após tipo e nome, chama `parse_array_suffix()` para capturar dimensões de array, depois o inicializador opcional. Produz `Decl::GlobalVar(qty, nome, init, span)`.
+
+---
+
+## Tipos (`parse_type`)
+
+O parse de tipos segue esta sequência:
+
+1. **Qualificadores** — loop que consome `const` e `unsigned` em qualquer ordem
+2. **Tipo base** — um dos: `int`, `long`, `short`, `char`, `float`, `double`, `void`, `struct Nome`
+3. **Ponteiros** — loop que consome `*`, envolvendo o tipo em `Type::Pointer(Box::new(ty))` a cada iteração
+
+```
+const unsigned int **  →  QualifierType {
+                              ty: Pointer(Pointer(Int)),
+                              is_const: true,
+                              is_unsigned: true,
+                          }
+```
+
+### Sufixo de Array (`parse_array_suffix`)
+
+Chamado após o nome da variável (não após o tipo), porque em C o `[N]` vem depois do identificador:
+
+```
+int arr[10][20]
+      ^^^^^^^^^  sufixo — envolve o tipo em Array(Array(Int))
+```
+
+O tamanho é consumido como expressão mas **não é armazenado** no AST (`Type::Array` carrega apenas o tipo do elemento).
+
+---
+
+## Statements (`parse_stmt`)
+
+O dispatcher reconhece o tipo pelo token atual:
+
+| Token | Statement |
+|---|---|
+| `{` | `Stmt::Block` |
+| `return` | `Stmt::Return(Option<Expr>)` |
+| `break` | `Stmt::Break` |
+| `continue` | `Stmt::Continue` |
+| `if` | `Stmt::If(cond, then, Option<else>)` |
+| `while` | `Stmt::While(cond, body)` |
+| `do` | `Stmt::DoWhile(cond, body)` |
+| `for` | `Stmt::For(init, cond, inc, body)` |
+| `switch` | `Stmt::Switch(expr, cases)` |
+| `starts_type()` | `Stmt::VarDecl(qty, nome, init)` |
+| qualquer outro | `Stmt::ExprStmt(expr)` |
+
+### For
+
+O `for` recebe tratamento especial para o inicializador:
+
+```
+for ( init ; cond ; inc ) body
+      ^^^^
+      pode ser:
+        - declaração de variável (tipo presente)
+        - expressão seguida de ;
+        - vazio (só ;)
+```
+
+### Switch
+
+Cases são coletados em loop. Cada `SwitchCase` acumula statements até encontrar outro `case`, `default` ou `}`:
+
+```rust
+struct SwitchCase {
+    label: SwitchLabel,    // Case(Expr) | Default
+    stmts: Vec<Stmt>,
+    span: Span,
+}
+```
+
+---
+
+## Expressões — Pratt Parser
+
+O Pratt parser é o algoritmo central para expressar precedência sem criar uma gramática recursiva de dezenas de níveis. Ele opera com **binding powers** (potências de ligação) em vez de regras gramaticais explícitas por precedência.
+
+### Conceito de Binding Power
+
+Cada operador tem dois valores:
+
+- **Left binding power (lbp)** — quão forte o operador puxa o token à sua esquerda
+- **Right binding power (rbp)** — quão forte puxa o token à sua direita
+
+A função `infix_binding_power(op)` retorna `(lbp, rbp, is_ternary)`:
+
+| Operadores | lbp / rbp |
+|---|---|
+| `=`, `+=`, `-=`, ... (atribuição) | 1 / 1 (associativo à direita) |
+| `\|\|` | 2 / 3 |
+| `&&` | 4 / 5 |
+| `\|` | 6 / 7 |
+| `^` | 8 / 9 |
+| `&` | 10 / 11 |
+| `==`, `!=` | 12 / 13 |
+| `<`, `>`, `<=`, `>=` | 14 / 15 |
+| `<<`, `>>` | 16 / 17 |
+| `+`, `-` | 18 / 19 |
+| `*`, `/`, `%` | 20 / 21 |
+
+Operadores unários prefix têm binding power fixo 30.
+
+### Algoritmo `parse_expr(min_bp)`
+
+```
+lhs = parse_prefix_expr()
+
+loop:
+    1. tenta parse_postfix(lhs)  → se consumiu algo, volta ao topo
+    2. lê operador infix atual
+    3. busca (lbp, rbp) para o operador
+    4. se lbp < min_bp → para (o operador pertence ao contexto acima)
+    5. consome operador
+    6. rhs = parse_expr(rbp)     → recursão com o rbp como novo mínimo
+    7. constrói nó Binary / Assign / CompoundAssign
+```
+
+O `min_bp` cresce a cada nível recursivo, garantindo que operadores de menor precedência não "roubem" operandos de operadores de maior precedência.
+
+**Exemplo:** `1 + 2 * 3`
+
+```
+parse_expr(0)
+  lhs = Literal(1)
+  operador '+' → lbp=18, rbp=19
+  18 >= 0 → consome '+'
+  rhs = parse_expr(19)
+    lhs = Literal(2)
+    operador '*' → lbp=20, rbp=21
+    20 >= 19 → consome '*'
+    rhs = parse_expr(21)
+      lhs = Literal(3)
+      sem mais operadores → retorna Literal(3)
+    retorna Binary(2, Mul, 3)
+  retorna Binary(1, Add, Binary(2, Mul, 3))
+```
+
+### Prefix Expressions
+
+Parseadas por `parse_prefix_expr()` antes do loop Pratt:
+
+| Token | Nó produzido |
+|---|---|
+| `IntLiteral(v)` | `Expr::Literal(Literal::Int(v))` |
+| `FloatLiteral(v)` | `Expr::Literal(Literal::Double(v))` |
+| `StringLiteral(v)` | `Expr::Literal(Literal::String(v))` |
+| `CharLiteral(v)` | `Expr::Literal(Literal::Char(v))` |
+| `Identifier(n)` | `Expr::Ident(n)` |
+| `-`, `!`, `~`, `*`, `&` | `Expr::Unary(op, inner)` |
+| `++`, `--` | `Expr::Prefix(op, inner)` |
+| `(tipo)` | `Expr::Cast(qty, inner)` |
+| `sizeof(tipo)` | `Expr::SizeofType(qty)` |
+| `sizeof expr` | `Expr::Sizeof(inner)` |
+| `(expr)` | agrupamento — retorna a expr interna |
+
+**Distinção cast vs. agrupamento:** ao ver `(`, o parser faz lookahead para verificar se o próximo token começa um tipo (`starts_type()`). Se sim, trata como cast; caso contrário, como agrupamento.
+
+**Distinção `sizeof(tipo)` vs. `sizeof expr`:** verifica se `(` é seguido de `starts_type()`. Se sim, consome tipo e fecha `)`; senão, parseia expressão normal.
+
+### Postfix Expressions
+
+`try_parse_postfix(lhs)` retorna `true` se consumiu algo:
+
+| Token | Nó produzido |
+|---|---|
+| `++` | `Expr::Postfix(PostfixOp::Inc, lhs)` |
+| `--` | `Expr::Postfix(PostfixOp::Dec, lhs)` |
+| `[` | `Expr::Index(lhs, idx)` — consome `expr ]` |
+| `(` | `Expr::Call(lhs, args)` — consome `args )` |
+| `.` | `Expr::Member(lhs, Direct, campo)` |
+| `->` | `Expr::Member(lhs, Pointer, campo)` |
+
+Postfix tem maior precedência efetiva que qualquer infix — o loop de postfix é tentado antes do loop infix a cada iteração.
+
+---
+
+## AST — Nós Produzidos
+
+### Decl
+
+```
+Decl::Function(retorno, nome, params, stmts, span)
+Decl::GlobalVar(qty, nome, Option<init>, span)
+Decl::StructDecl(nome, campos, span)
+```
+
+### Stmt
+
+```
+Stmt::Block(stmts, span)
+Stmt::VarDecl(qty, nome, Option<init>, span)
+Stmt::ExprStmt(expr, span)
+Stmt::Return(Option<expr>, span)
+Stmt::If(cond, then, Option<else>, span)
+Stmt::While(cond, body, span)
+Stmt::DoWhile(cond, body, span)
+Stmt::For(Option<init>, Option<cond>, Option<inc>, body, span)
+Stmt::Switch(expr, cases, span)
+Stmt::Break(span)
+Stmt::Continue(span)
+```
+
+### Expr
+
+```
+Expr::Literal(Literal, span)
+Expr::Ident(String, span)
+Expr::Binary(lhs, BinOp, rhs, span)
+Expr::Unary(UnOp, inner, span)
+Expr::Prefix(PrefixOp, inner, span)
+Expr::Postfix(PostfixOp, inner, span)
+Expr::Assign(lhs, rhs, span)
+Expr::CompoundAssign(BinOp, lhs, rhs, span)
+Expr::Call(callee, args, span)
+Expr::Index(arr, idx, span)
+Expr::Cast(QualifierType, inner, span)
+Expr::Sizeof(inner, span)
+Expr::SizeofType(QualifierType, span)
+Expr::Ternary(cond, then, else, span)
+Expr::Member(obj, MemberAccess, campo, span)
+```
+
+### Type
+
+```
+Type::Int | Long | Short | Char | Float | Double | Void
+Type::Pointer(Box<Type>)
+Type::Array(Box<Type>)      ← tamanho não armazenado
+Type::Struct(String)        ← referência por nome
+
+QualifierType {
+    ty: Type,
+    is_const: bool,
+    is_unsigned: bool,
+}
+```


### PR DESCRIPTION
This pull request adds comprehensive documentation for both the lexer and parser components of the project. The new docs detail the internal APIs, tokenization/parsing flow, error handling strategies, and the structure of the produced AST. These documents are intended to help developers understand the implementation and design decisions behind the language front-end.

**Lexer Documentation (`docs/lexer.md`):**

- Provides an overview of the lexer's responsibilities, including token generation and error accumulation.
- Documents the character-by-character reading API of `SourceFile`, tokenization rules, and how the scanner loop operates.
- Explains handling of comments, preprocessor directives, balanced delimiters, and numeric/string/char literal parsing, including error diagnostics.
- Lists token categories, error types, and how spans are tracked for diagnostics.

**Parser Documentation (`docs/parser.md`):**

- Describes the parser's high-level operation, error recovery strategy, and the main parsing loop.
- Details the parser's internal API, including lookahead and synchronization methods.
- Outlines the parsing hierarchy for global declarations, statements, and expressions, with special attention to C-specific constructs (e.g., type parsing, array suffixes, and the Pratt parser for expressions).
- Provides a full description of the produced AST node types for declarations, statements, expressions, and types.