### PR TITLE
Feat/issue110 enum and typedef

### DIFF
--- a/src/common/ast/ast.rs
+++ b/src/common/ast/ast.rs
@@ -11,6 +11,8 @@ pub enum Type {
     Array(Box<Type>),   //Determinar os tipos de arrays
     Pointer(Box<Type>), // olhar onde pode usar
     Struct(String),
+    Enum(String),
+    Alias(String),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/common/ast/decl.rs
+++ b/src/common/ast/decl.rs
@@ -12,6 +12,8 @@ pub enum Decl {
     ),
     GlobalVar(QualifierType, String, Option<Expr>, Span),
     StructDecl(String, Vec<(QualifierType, String)>, Span),
+    EnumDecl(Option<String>, Vec<(String, Option<Expr>)>, Span),
+    Typedef(QualifierType, String, Span),
 }
 
 impl Decl {
@@ -21,6 +23,8 @@ impl Decl {
             Decl::Function(_, _, _, _, s) => s.clone(),
             Decl::GlobalVar(_, _, _, s) => s.clone(),
             Decl::StructDecl(_, _, s) => s.clone(),
+            Decl::EnumDecl(_, _, s) => s.clone(),
+            Decl::Typedef(_, _, s) => s.clone(),
         }
     }
 }

--- a/src/examples/typedef_enum.c
+++ b/src/examples/typedef_enum.c
@@ -1,0 +1,10 @@
+typedef int Integer;
+
+enum Color {
+    RED = 0,
+    GREEN,
+    BLUE
+};
+
+Integer value;
+enum Color color;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -6,6 +6,7 @@ use crate::common::errors::types::{CompilerError, SyntaxError};
 use crate::lexer::tokens::token::Token;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::rules::expressions::{infix, postfix, prefix};
+use std::collections::HashSet;
 
 type Diagnostic = CompilerError;
 
@@ -13,17 +14,51 @@ type Diagnostic = CompilerError;
 pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
+    type_names: HashSet<String>,
 }
 
 impl Parser {
     /// Cria um novo `Parser` a partir de um vetor de tokens produzido pelo `Scanner`.
     pub fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, pos: 0 }
+        Self {
+            tokens,
+            pos: 0,
+            type_names: HashSet::new(),
+        }
     }
 
     pub(crate) fn peek_next(&self) -> &Token {
-        let next = (self.pos + 1).min(self.tokens.len() - 1);
+        self.peek_n(1)
+    }
+
+    pub(crate) fn peek_n(&self, offset: usize) -> &Token {
+        let next = (self.pos + offset).min(self.tokens.len() - 1);
         &self.tokens[next]
+    }
+
+    pub(crate) fn register_type_name(&mut self, name: String) {
+        self.type_names.insert(name);
+    }
+
+    pub(crate) fn is_type_name(&self, kind: &TokenKind) -> bool {
+        match kind {
+            TokenKind::Const
+            | TokenKind::Unsigned
+            | TokenKind::Int
+            | TokenKind::Long
+            | TokenKind::Float
+            | TokenKind::Double
+            | TokenKind::Struct
+            | TokenKind::Enum
+            | TokenKind::Void
+            | TokenKind::Char => true,
+            TokenKind::Identifier(name) => self.type_names.contains(name),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn starts_type(&self) -> bool {
+        self.is_type_name(self.peek_kind())
     }
 
     /// Parseia uma expressão com precedência mínima `min_bp` usando o algoritmo Pratt (top-down operator precedence).

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -18,6 +18,14 @@ pub fn parse_program(parser: &mut Parser) -> Result<Program, CompilerError> {
 
 /// Dispatcher do escopo global: tipo + lookahead para distinguir função de variável global.
 fn parse_global_item(parser: &mut Parser) -> Result<Decl, CompilerError> {
+    if parser.check(&TokenKind::Typedef) {
+        return parse_typedef_decl(parser);
+    }
+
+    if is_enum_definition(parser) {
+        return parse_enum_decl(parser);
+    }
+
     let start = parser.peek().clone();
     let qty = parse_type(parser)?;
 
@@ -113,4 +121,89 @@ pub(crate) fn parse_global_var_decl(
         .clone();
     let span = parser.join_span(parser.span_of(&start), parser.span_of(&semi));
     Ok(Decl::GlobalVar(qty, name, init, span))
+}
+
+fn parse_typedef_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
+    let start = parser.expect(&TokenKind::Typedef, "'typedef'")?.clone();
+    let qty = parse_type(parser)?;
+
+    let name_token = parser.advance().clone();
+    let TokenKind::Identifier(alias) = name_token.kind else {
+        return Err(parser.syntax_error(
+            &name_token,
+            "nome do typedef",
+            &format!("{:?}", name_token.kind),
+        ));
+    };
+
+    let semi = parser
+        .expect(&TokenKind::Semicolon, "';' ao fim do typedef")?
+        .clone();
+    parser.register_type_name(alias.clone());
+    let span = parser.join_span(parser.span_of(&start), parser.span_of(&semi));
+    Ok(Decl::Typedef(qty, alias, span))
+}
+
+fn parse_enum_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
+    let start = parser.expect(&TokenKind::Enum, "'enum'")?.clone();
+
+    let name = if matches!(parser.peek_kind(), TokenKind::Identifier(_))
+        && parser.peek_next().kind == TokenKind::LeftBrace
+    {
+        let name_token = parser.advance().clone();
+        let TokenKind::Identifier(name) = name_token.kind else {
+            unreachable!();
+        };
+        Some(name)
+    } else {
+        None
+    };
+
+    parser.expect(&TokenKind::LeftBrace, "'{' após enum")?;
+
+    let mut variants = Vec::new();
+    while !parser.check(&TokenKind::RightBrace) && !parser.is_at_end() {
+        let variant_token = parser.advance().clone();
+        let TokenKind::Identifier(variant_name) = variant_token.kind else {
+            return Err(parser.syntax_error(
+                &variant_token,
+                "nome de variante de enum",
+                &format!("{:?}", variant_token.kind),
+            ));
+        };
+
+        let value = if parser.match_kind(&TokenKind::Equal) {
+            Some(parser.parse_expr(0)?)
+        } else {
+            None
+        };
+
+        variants.push((variant_name, value));
+
+        if parser.match_kind(&TokenKind::Comma) {
+            continue;
+        }
+        break;
+    }
+
+    let rbrace = parser
+        .expect(&TokenKind::RightBrace, "'}' ao fim do enum")?
+        .clone();
+    let semi = parser
+        .expect(&TokenKind::Semicolon, "';' ao fim da declaração de enum")?
+        .clone();
+
+    let span = parser.join_span(parser.span_of(&start), parser.span_of(&semi));
+    let _ = rbrace;
+    Ok(Decl::EnumDecl(name, variants, span))
+}
+
+fn is_enum_definition(parser: &Parser) -> bool {
+    if !parser.check(&TokenKind::Enum) {
+        return false;
+    }
+
+    matches!(parser.peek_next().kind, TokenKind::LeftBrace)
+        || (matches!(parser.peek_next().kind, TokenKind::Identifier(_))
+            && parser.peek_n(2).kind == TokenKind::LeftBrace)
 }

--- a/src/parser/rules/declarations/types.rs
+++ b/src/parser/rules/declarations/types.rs
@@ -14,6 +14,7 @@ pub fn starts_type(kind: &TokenKind) -> bool {
             | TokenKind::Float
             | TokenKind::Double
             | TokenKind::Struct
+            | TokenKind::Enum
             | TokenKind::Void
             | TokenKind::Char
     )
@@ -68,6 +69,19 @@ pub fn parse_type(parser: &mut Parser) -> Result<QualifierType, CompilerError> {
                 return Err(parser.syntax_error(&t, "nome de struct", &format!("{:?}", t.kind)));
             };
             Type::Struct(name)
+        }
+        TokenKind::Enum => {
+            parser.advance();
+            let t = parser.advance().clone();
+            let TokenKind::Identifier(name) = t.kind else {
+                return Err(parser.syntax_error(&t, "nome de enum", &format!("{:?}", t.kind)));
+            };
+            Type::Enum(name)
+        }
+        TokenKind::Identifier(name) if parser.is_type_name(parser.peek_kind()) => {
+            let name = name.clone();
+            parser.advance();
+            Type::Alias(name)
         }
         _ => {
             let found = parser.peek().clone();

--- a/src/parser/rules/expressions/prefix.rs
+++ b/src/parser/rules/expressions/prefix.rs
@@ -82,7 +82,7 @@ pub fn looks_like_cast(parser: &Parser) -> bool {
     }
 
     let next = parser.peek_next();
-    crate::parser::rules::declarations::starts_type(&next.kind)
+    parser.is_type_name(&next.kind)
 }
 
 /// Parseia o tipo dentro de um cast, incluindo qualificadores `const`/`unsigned` e ponteiros `*`.

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -22,7 +22,7 @@ pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         TokenKind::Do => parse_do_while(parser),
         TokenKind::For => parse_for(parser),
         TokenKind::Switch => parse_switch(parser),
-        _ if declarations::starts_type(parser.peek_kind()) => declarations::parse_var_decl(parser),
+        _ if parser.starts_type() => declarations::parse_var_decl(parser),
         _ => parse_expr_stmt(parser),
     }
 }
@@ -148,7 +148,7 @@ fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
     let init = if parser.check(&TokenKind::Semicolon) {
         parser.advance();
         None
-    } else if declarations::starts_type(parser.peek_kind()) {
+    } else if parser.starts_type() {
         Some(Box::new(declarations::parse_var_decl(parser)?))
     } else {
         let expr = parser.parse_expr(0)?;

--- a/src/tests/parser_file_test.rs
+++ b/src/tests/parser_file_test.rs
@@ -56,6 +56,17 @@ mod tests {
     }
 
     #[test]
+    fn typedef_and_enum_are_parsed_and_register_types() {
+        let program = parse_file("typedef_enum.c");
+
+        assert_eq!(program.decls.len(), 4, "esperado 4 declarações globais");
+        assert!(matches!(&program.decls[0], Decl::Typedef(_, alias, _) if alias == "Integer"));
+        assert!(matches!(&program.decls[1], Decl::EnumDecl(Some(name), _, _) if name == "Color"));
+        assert!(matches!(&program.decls[2], Decl::GlobalVar(_, name, _, _) if name == "value"));
+        assert!(matches!(&program.decls[3], Decl::GlobalVar(_, name, _, _) if name == "color"));
+    }
+
+    #[test]
     fn hello_world_has_printf_call_and_return() {
         let program = parse_file("hello_world.c");
 

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -403,8 +403,15 @@ mod tests {
         let mut parser = Parser::new(tokens);
         let program = parser.parse_program().expect("programa com typedef válido");
 
-        assert!(matches!(program.decls[0], Decl::Typedef(_, ref alias, _) if alias == "Integer"));
-        assert!(matches!(program.decls[1], Decl::GlobalVar(ref qty, ref name, _, _) if name == "value" && matches!(qty.ty, Type::Alias(ref alias) if alias == "Integer")));
+        assert!(matches!(
+            program.decls[0],
+            Decl::Typedef(_, ref alias, _) if alias == "Integer"
+        ));
+        assert!(matches!(
+            program.decls[1],
+            Decl::GlobalVar(ref qty, ref name, _, _)
+                if name == "value" && matches!(qty.ty, Type::Alias(ref alias) if alias == "Integer")
+        ));
     }
 
     #[test]

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -388,6 +388,54 @@ mod tests {
     }
 
     #[test]
+    fn parses_typedef_then_uses_alias_as_type() {
+        let tokens = vec![
+            tk(TokenKind::Typedef, 1),
+            tk(TokenKind::Int, 10),
+            ident("Integer", 14),
+            tk(TokenKind::Semicolon, 21),
+            ident("Integer", 23),
+            ident("value", 31),
+            tk(TokenKind::Semicolon, 36),
+            eof(37),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let program = parser.parse_program().expect("programa com typedef válido");
+
+        assert!(matches!(program.decls[0], Decl::Typedef(_, ref alias, _) if alias == "Integer"));
+        assert!(matches!(program.decls[1], Decl::GlobalVar(ref qty, ref name, _, _) if name == "value" && matches!(qty.ty, Type::Alias(ref alias) if alias == "Integer")));
+    }
+
+    #[test]
+    fn parses_enum_definition() {
+        let tokens = vec![
+            tk(TokenKind::Enum, 1),
+            ident("Color", 6),
+            tk(TokenKind::LeftBrace, 12),
+            ident("RED", 14),
+            tk(TokenKind::Equal, 18),
+            int(0, 20),
+            tk(TokenKind::Comma, 21),
+            ident("GREEN", 23),
+            tk(TokenKind::Comma, 28),
+            ident("BLUE", 30),
+            tk(TokenKind::RightBrace, 35),
+            tk(TokenKind::Semicolon, 36),
+            eof(37),
+        ];
+
+        let mut parser = Parser::new(tokens);
+        let program = parser.parse_program().expect("enum válido");
+
+        let Decl::EnumDecl(Some(name), variants, _) = &program.decls[0] else {
+            panic!("esperava Decl::EnumDecl");
+        };
+        assert_eq!(name, "Color");
+        assert_eq!(variants.len(), 3);
+    }
+
+    #[test]
     fn parses_expr_stmt() {
         let tokens = vec![
             ident("x", 1),


### PR DESCRIPTION
**Título do PR**
Suporte a `enum` e `typedef` no parser

**Descrição**
Este PR adiciona suporte ao parsing de declarações `enum` e `typedef`, que antes eram rejeitadas pelo parser. Com isso, o compilador passa a reconhecer essas construções e a seguir com a análise normalmente, em vez de falhar logo no início.

Além disso, aliases criados por `typedef` passam a ser registrados durante o parsing, permitindo seu uso como tipo em declarações subsequentes. A AST também foi expandida para representar essas novas formas de declaração, e foram incluídos testes cobrindo os principais cenários.

**O que mudou**
- O parser agora aceita declarações `enum`.
- O parser agora aceita declarações `typedef`.
- Aliases de tipo definidos com `typedef` passam a ser reutilizáveis como nome de tipo.
- A AST foi ajustada para representar `enum` e `typedef`.
- Foram adicionados testes para parsing em memória e por arquivo.

**Validação**
- `cargo test`

Se quiser, posso também transformar isso em um texto mais “polido de PR real”, com seções como `Motivação`, `Como testar` e `Observações`.