### PR TITLE
feat(parser): add enum and typedef support (issue110)

### DIFF
--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -36,10 +36,11 @@ impl SemanticAnalyser {
                 if let Some(expr) = init {
                     self.analyse_expr(expr);
                 }
+                let resolved_qty = self.resolve_type(qty);
                 let symbol = Symbol {
                     name: name.clone(),
-                    ty: qty.clone(),
-                    mutable: !qty.is_const,
+                    ty: resolved_qty.clone(),
+                    mutable: !resolved_qty.is_const,
                     decl_span: span.clone(),
                 };
                 if let Err(e) = self.sym.declare(symbol) {
@@ -49,15 +50,45 @@ impl SemanticAnalyser {
             Decl::StructDecl(name, fields, _) => {
                 self.sym.register_struct(name.clone(), fields.clone());
             }
+            Decl::EnumDecl(_, variants, enum_span) => {
+                for (variant_name, value) in variants {
+                    if let Some(expr) = value {
+                        self.analyse_expr(expr);
+                    }
+
+                    let symbol = Symbol {
+                        name: variant_name.clone(),
+                        ty: QualifierType {
+                            ty: Type::Int,
+                            is_const: true,
+                            is_unsigned: false,
+                        },
+                        mutable: false,
+                        decl_span: value
+                            .as_ref()
+                            .map(|expr| expr.span())
+                            .unwrap_or_else(|| enum_span.clone()),
+                    };
+
+                    if let Err(e) = self.sym.declare(symbol) {
+                        self.diagnostics.push(e);
+                    }
+                }
+            }
+            Decl::Typedef(qty, name, _) => {
+                let resolved_qty = self.resolve_type(qty);
+                self.sym.register_type_alias(name.clone(), resolved_qty);
+            }
             Decl::Function(return_type, _name, params, body, span) => {
                 self.sym.enter_scope();
-                let prev_ret = self.current_fn_ret.replace(return_type.clone());
+                let prev_ret = self.current_fn_ret.replace(self.resolve_type(return_type));
 
                 for (qty, name) in params {
+                    let resolved_qty = self.resolve_type(qty);
                     let symbol = Symbol {
                         name: name.clone(),
-                        ty: qty.clone(),
-                        mutable: !qty.is_const,
+                        ty: resolved_qty.clone(),
+                        mutable: !resolved_qty.is_const,
                         decl_span: span.clone(),
                     };
                     if let Err(e) = self.sym.declare(symbol) {
@@ -81,10 +112,11 @@ impl SemanticAnalyser {
                 if let Some(expr) = init {
                     self.analyse_expr(expr);
                 }
+                let resolved_qty = self.resolve_type(qty);
                 let symbol = Symbol {
                     name: name.clone(),
-                    ty: qty.clone(),
-                    mutable: !qty.is_const,
+                    ty: resolved_qty.clone(),
+                    mutable: !resolved_qty.is_const,
                     decl_span: span.clone(),
                 };
                 if let Err(e) = self.sym.declare(symbol) {
@@ -196,7 +228,7 @@ impl SemanticAnalyser {
             }
             Expr::Cast(qty, e, _) => {
                 self.analyse_expr(e);
-                qty.clone()
+                self.resolve_type(qty)
             }
             Expr::Sizeof(e, _) => {
                 self.analyse_expr(e);
@@ -305,6 +337,27 @@ impl SemanticAnalyser {
                     }
                 }
             }
+        }
+    }
+
+    fn resolve_type(&self, qty: &QualifierType) -> QualifierType {
+        QualifierType {
+            ty: self.resolve_type_inner(&qty.ty),
+            is_const: qty.is_const,
+            is_unsigned: qty.is_unsigned,
+        }
+    }
+
+    fn resolve_type_inner(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Array(inner) => Type::Array(Box::new(self.resolve_type_inner(inner))),
+            Type::Pointer(inner) => Type::Pointer(Box::new(self.resolve_type_inner(inner))),
+            Type::Alias(name) => self
+                .sym
+                .lookup_type_alias(name)
+                .map(|resolved| self.resolve_type(resolved).ty)
+                .unwrap_or_else(|| Type::Alias(name.clone())),
+            other => other.clone(),
         }
     }
 }

--- a/src/analyser/symbol_table.rs
+++ b/src/analyser/symbol_table.rs
@@ -18,6 +18,7 @@ pub struct SymbolTable {
     scopes: Vec<HashMap<String, Symbol>>,
 
     struct_table: HashMap<String, Vec<(QualifierType, String)>>,
+    type_aliases: HashMap<String, QualifierType>,
 }
 
 impl SymbolTable {
@@ -62,5 +63,13 @@ impl SymbolTable {
 
     pub fn lookup_struct(&self, name: &str) -> Option<&[(QualifierType, String)]> {
         self.struct_table.get(name).map(|v| v.as_slice())
+    }
+
+    pub fn register_type_alias(&mut self, name: String, ty: QualifierType) {
+        self.type_aliases.insert(name, ty);
+    }
+
+    pub fn lookup_type_alias(&self, name: &str) -> Option<&QualifierType> {
+        self.type_aliases.get(name)
     }
 }

--- a/src/common/ast/ast.rs
+++ b/src/common/ast/ast.rs
@@ -13,6 +13,8 @@ pub enum Type {
     Array(Box<Type>),
     Pointer(Box<Type>),
     Struct(String),
+    Enum(String),
+    Alias(String),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/common/ast/decl.rs
+++ b/src/common/ast/decl.rs
@@ -12,6 +12,8 @@ pub enum Decl {
     ),
     GlobalVar(QualifierType, String, Option<Expr>, Span),
     StructDecl(String, Vec<(QualifierType, String)>, Span),
+    EnumDecl(String, Vec<(String, Option<Expr>)>, Span),
+    Typedef(QualifierType, String, Span),
 }
 
 impl Decl {
@@ -21,6 +23,8 @@ impl Decl {
             Decl::Function(_, _, _, _, s) => s.clone(),
             Decl::GlobalVar(_, _, _, s) => s.clone(),
             Decl::StructDecl(_, _, s) => s.clone(),
+            Decl::EnumDecl(_, _, s) => s.clone(),
+            Decl::Typedef(_, _, s) => s.clone(),
         }
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -6,6 +6,7 @@ use crate::common::errors::types::{CompilerError, SyntaxError};
 use crate::lexer::tokens::token::Token;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::rules::expressions::{infix, postfix, prefix};
+use std::collections::HashSet;
 
 type Diagnostic = CompilerError;
 
@@ -13,6 +14,7 @@ pub struct Parser {
     tokens: Vec<Token>,
     pos: usize,
     pub(crate) diagnostics: Vec<CompilerError>,
+    type_names: HashSet<String>,
 }
 
 impl Parser {
@@ -21,7 +23,16 @@ impl Parser {
             tokens,
             pos: 0,
             diagnostics: Vec::new(),
+            type_names: HashSet::new(),
         }
+    }
+
+    pub(crate) fn register_type_name(&mut self, name: String) {
+        self.type_names.insert(name);
+    }
+
+    pub(crate) fn is_type_name(&self, name: &str) -> bool {
+        self.type_names.contains(name)
     }
 
     pub(crate) fn peek_next(&self) -> &Token {

--- a/src/parser/rules/declarations/mod.rs
+++ b/src/parser/rules/declarations/mod.rs
@@ -3,5 +3,5 @@ pub mod types;
 pub mod var_decl;
 
 pub use top_level::parse_program;
-pub use types::{parse_array_suffix, parse_type, starts_type};
+pub use types::{parse_array_suffix, parse_type, starts_type, starts_type_kind};
 pub use var_decl::parse_var_decl;

--- a/src/parser/rules/declarations/top_level.rs
+++ b/src/parser/rules/declarations/top_level.rs
@@ -31,6 +31,17 @@ pub fn parse_program(parser: &mut Parser) -> Result<Program, Vec<CompilerError>>
 fn parse_global_item(parser: &mut Parser) -> Result<Decl, CompilerError> {
     let start = parser.peek().clone();
 
+    if parser.check(&TokenKind::Typedef) {
+        return parse_typedef_decl(parser);
+    }
+
+    if parser.check(&TokenKind::Enum)
+        && matches!(parser.peek_at(1).kind, TokenKind::Identifier(_))
+        && parser.peek_at(2).kind == TokenKind::LeftBrace
+    {
+        return parse_enum_decl(parser);
+    }
+
     if parser.check(&TokenKind::Struct)
         && matches!(parser.peek_at(1).kind, TokenKind::Identifier(_))
         && parser.peek_at(2).kind == TokenKind::LeftBrace
@@ -151,6 +162,78 @@ fn parse_struct_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
 
     let span = parser.join_span(parser.span_of(&start), parser.span_of(&end));
     Ok(Decl::StructDecl(name, fields, span))
+}
+
+/// Parseia uma definição de enum: `enum Name { VAR = expr, ... };`
+fn parse_enum_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
+    let start = parser.advance().clone();
+
+    let name_token = parser.advance().clone();
+    let TokenKind::Identifier(name) = name_token.kind else {
+        return Err(parser.syntax_error(
+            &name_token,
+            "nome do enum",
+            &format!("{:?}", name_token.kind),
+        ));
+    };
+
+    parser.expect(&TokenKind::LeftBrace, "'{' após nome do enum")?;
+
+    let mut variants = Vec::new();
+    while !parser.check(&TokenKind::RightBrace) && !parser.is_at_end() {
+        let variant_token = parser.advance().clone();
+        let TokenKind::Identifier(variant_name) = variant_token.kind else {
+            return Err(parser.syntax_error(
+                &variant_token,
+                "nome do variant",
+                &format!("{:?}", variant_token.kind),
+            ));
+        };
+
+        let value = if parser.match_kind(&TokenKind::Equal) {
+            Some(parser.parse_expr(0)?)
+        } else {
+            None
+        };
+
+        variants.push((variant_name, value));
+
+        if !parser.match_kind(&TokenKind::Comma) {
+            break;
+        }
+    }
+
+    let end = parser
+        .expect(&TokenKind::RightBrace, "'}' ao fim do enum")?
+        .clone();
+    parser.expect(&TokenKind::Semicolon, "';' após definição de enum")?;
+
+    let span = parser.join_span(parser.span_of(&start), parser.span_of(&end));
+    Ok(Decl::EnumDecl(name, variants, span))
+}
+
+/// Parseia um typedef: `typedef <tipo> <alias>;`
+fn parse_typedef_decl(parser: &mut Parser) -> Result<Decl, CompilerError> {
+    let start = parser.expect(&TokenKind::Typedef, "'typedef'")?.clone();
+    let qty = parse_type(parser)?;
+
+    let alias_token = parser.advance().clone();
+    let TokenKind::Identifier(alias) = alias_token.kind else {
+        return Err(parser.syntax_error(
+            &alias_token,
+            "nome do alias",
+            &format!("{:?}", alias_token.kind),
+        ));
+    };
+
+    let end = parser
+        .expect(&TokenKind::Semicolon, "';' após typedef")?
+        .clone();
+
+    parser.register_type_name(alias.clone());
+
+    let span = parser.join_span(parser.span_of(&start), parser.span_of(&end));
+    Ok(Decl::Typedef(qty, alias, span))
 }
 
 /// Continua o parsing de uma variável global após tipo e nome: `([N])? (= expr)? ;`.

--- a/src/parser/rules/declarations/types.rs
+++ b/src/parser/rules/declarations/types.rs
@@ -22,20 +22,26 @@ pub fn parse_array_suffix(
 }
 
 // Retorna `true` se o token inicia uma declaração de tipo
-pub fn starts_type(kind: &TokenKind) -> bool {
-    matches!(
-        kind,
+pub fn starts_type(parser: &Parser) -> bool {
+    starts_type_kind(parser, parser.peek_kind())
+}
+
+pub fn starts_type_kind(parser: &Parser, kind: &TokenKind) -> bool {
+    match kind {
         TokenKind::Const
-            | TokenKind::Unsigned
-            | TokenKind::Int
-            | TokenKind::Long
-            | TokenKind::Short
-            | TokenKind::Float
-            | TokenKind::Double
-            | TokenKind::Struct
-            | TokenKind::Void
-            | TokenKind::Char
-    )
+        | TokenKind::Unsigned
+        | TokenKind::Int
+        | TokenKind::Long
+        | TokenKind::Short
+        | TokenKind::Float
+        | TokenKind::Double
+        | TokenKind::Struct
+        | TokenKind::Void
+        | TokenKind::Char
+        | TokenKind::Enum => true,
+        TokenKind::Identifier(name) => parser.is_type_name(name),
+        _ => false,
+    }
 }
 
 /// Parseia um tipo C completo: `const? Unsigned? base *...`
@@ -90,6 +96,19 @@ pub fn parse_type(parser: &mut Parser) -> Result<QualifierType, CompilerError> {
                 return Err(parser.syntax_error(&t, "nome de struct", &format!("{:?}", t.kind)));
             };
             Type::Struct(name)
+        }
+        TokenKind::Enum => {
+            parser.advance();
+            let t = parser.advance().clone();
+            let TokenKind::Identifier(name) = t.kind else {
+                return Err(parser.syntax_error(&t, "nome de enum", &format!("{:?}", t.kind)));
+            };
+            Type::Enum(name)
+        }
+        TokenKind::Identifier(name) if parser.is_type_name(name) => {
+            let name = name.clone();
+            parser.advance();
+            Type::Alias(name)
         }
         _ => {
             let found = parser.peek().clone();

--- a/src/parser/rules/expressions/prefix.rs
+++ b/src/parser/rules/expressions/prefix.rs
@@ -3,7 +3,7 @@ use crate::common::errors::error_data::Span;
 use crate::common::errors::types::CompilerError;
 use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
-use crate::parser::rules::declarations::{parse_type, starts_type};
+use crate::parser::rules::declarations::{parse_type, starts_type_kind};
 
 /// Parseia uma expressão prefix: operadores unários, literais, identificadores, agrupamentos e casts.
 /// É o ponto de entrada principal do lado esquerdo no algoritmo Pratt.
@@ -15,7 +15,7 @@ pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr, CompilerError> {
     if kind == TokenKind::Sizeof {
         let sizeof_token = parser.advance().clone();
 
-        if parser.check(&TokenKind::LeftParen) && starts_type(&parser.peek_next().kind) {
+        if parser.check(&TokenKind::LeftParen) && starts_type_kind(parser, &parser.peek_next().kind) {
             parser.expect(&TokenKind::LeftParen, "'(' após sizeof")?; // verifica se é um ( se for consome e passa pro próximo token
 
             let ty = parse_type(parser)?; // vai guardar tudo que faz parte do entendimento do tipo (*int), (unsiged int),...
@@ -113,7 +113,7 @@ pub fn looks_like_cast(parser: &Parser) -> bool {
     }
 
     let next = parser.peek_next();
-    crate::parser::rules::declarations::starts_type(&next.kind)
+    starts_type_kind(parser, &next.kind)
 }
 
 /// Constrói o nó de expressão prefix correto para o operador `op` aplicado sobre `rhs`.

--- a/src/parser/rules/expressions/prefix.rs
+++ b/src/parser/rules/expressions/prefix.rs
@@ -15,7 +15,8 @@ pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr, CompilerError> {
     if kind == TokenKind::Sizeof {
         let sizeof_token = parser.advance().clone();
 
-        if parser.check(&TokenKind::LeftParen) && starts_type_kind(parser, &parser.peek_next().kind) {
+        if parser.check(&TokenKind::LeftParen) && starts_type_kind(parser, &parser.peek_next().kind)
+        {
             parser.expect(&TokenKind::LeftParen, "'(' após sizeof")?; // verifica se é um ( se for consome e passa pro próximo token
 
             let ty = parse_type(parser)?; // vai guardar tudo que faz parte do entendimento do tipo (*int), (unsiged int),...

--- a/src/parser/rules/statements/basic.rs
+++ b/src/parser/rules/statements/basic.rs
@@ -22,7 +22,7 @@ pub fn parse_stmt(parser: &mut Parser) -> Result<Stmt, CompilerError> {
         TokenKind::Do => parse_do_while(parser),
         TokenKind::For => parse_for(parser),
         TokenKind::Switch => parse_switch(parser),
-        _ if declarations::starts_type(parser.peek_kind()) => declarations::parse_var_decl(parser),
+        _ if declarations::starts_type(parser) => declarations::parse_var_decl(parser),
         _ => parse_expr_stmt(parser),
     }
 }
@@ -148,7 +148,7 @@ fn parse_for(parser: &mut Parser) -> Result<Stmt, CompilerError> {
     let init = if parser.check(&TokenKind::Semicolon) {
         parser.advance();
         None
-    } else if declarations::starts_type(parser.peek_kind()) {
+    } else if declarations::starts_type(parser) {
         Some(Box::new(declarations::parse_var_decl(parser)?))
     } else {
         let expr = parser.parse_expr(0)?;

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1720,7 +1720,10 @@ mod tests {
         assert_eq!(name, "Color");
         assert_eq!(variants.len(), 3);
         assert_eq!(variants[0].0, "RED");
-        assert!(matches!(variants[0].1, Some(Expr::Literal(Literal::Int(0), _))));
+        assert!(matches!(
+            variants[0].1,
+            Some(Expr::Literal(Literal::Int(0), _))
+        ));
         assert_eq!(variants[1].0, "GREEN");
         assert!(variants[1].1.is_none());
         assert_eq!(variants[2].0, "BLUE");

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -1694,6 +1694,69 @@ mod tests {
         assert!(matches!(prog.decls[1], Decl::GlobalVar(_, _, _, _)));
     }
 
+    #[test]
+    fn parses_enum_decl() {
+        // enum Color { RED = 0, GREEN, BLUE };
+        let tokens = vec![
+            tk(TokenKind::Enum, 1),
+            ident("Color", 6),
+            tk(TokenKind::LeftBrace, 12),
+            ident("RED", 14),
+            tk(TokenKind::Equal, 18),
+            int(0, 20),
+            tk(TokenKind::Comma, 21),
+            ident("GREEN", 23),
+            tk(TokenKind::Comma, 28),
+            ident("BLUE", 30),
+            tk(TokenKind::RightBrace, 34),
+            tk(TokenKind::Semicolon, 35),
+            eof(36),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser.parse_program().expect("deve parsear enum");
+        let Decl::EnumDecl(name, variants, _) = &prog.decls[0] else {
+            panic!("esperava Decl::EnumDecl");
+        };
+        assert_eq!(name, "Color");
+        assert_eq!(variants.len(), 3);
+        assert_eq!(variants[0].0, "RED");
+        assert!(matches!(variants[0].1, Some(Expr::Literal(Literal::Int(0), _))));
+        assert_eq!(variants[1].0, "GREEN");
+        assert!(variants[1].1.is_none());
+        assert_eq!(variants[2].0, "BLUE");
+        assert!(variants[2].1.is_none());
+    }
+
+    #[test]
+    fn parses_typedef_and_uses_alias_as_type() {
+        // typedef int Integer; Integer x;
+        let tokens = vec![
+            tk(TokenKind::Typedef, 1),
+            tk(TokenKind::Int, 10),
+            ident("Integer", 14),
+            tk(TokenKind::Semicolon, 21),
+            ident("Integer", 23),
+            ident("x", 31),
+            tk(TokenKind::Semicolon, 32),
+            eof(33),
+        ];
+        let mut parser = Parser::new(tokens);
+        let prog = parser
+            .parse_program()
+            .expect("deve parsear typedef seguido de uso do alias");
+        assert_eq!(prog.decls.len(), 2);
+        let Decl::Typedef(qty, alias, _) = &prog.decls[0] else {
+            panic!("esperava Decl::Typedef");
+        };
+        assert!(matches!(qty.ty, Type::Int));
+        assert_eq!(alias, "Integer");
+        let Decl::GlobalVar(qty, name, _, _) = &prog.decls[1] else {
+            panic!("esperava Decl::GlobalVar");
+        };
+        assert_eq!(name, "x");
+        assert!(matches!(&qty.ty, Type::Alias(alias) if alias == "Integer"));
+    }
+
     // ── long / short ──────────────────────────────────────────────────────────
 
     #[test]

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -191,12 +191,12 @@ mod tests {
     fn typedef_alias_resolves_before_member_access() {
         let prog = Program {
             decls: vec![
-                Decl::StructDecl(
-                    "Point".into(),
-                    vec![(qty(Type::Int), "x".into())],
+                Decl::StructDecl("Point".into(), vec![(qty(Type::Int), "x".into())], span()),
+                Decl::Typedef(
+                    qty(Type::Struct("Point".into())),
+                    "PointAlias".into(),
                     span(),
                 ),
-                Decl::Typedef(qty(Type::Struct("Point".into())), "PointAlias".into(), span()),
                 Decl::Function(
                     qty(Type::Void),
                     "main".into(),

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use crate::analyser::SemanticAnalyser;
     use crate::common::ast::ast::{Program, QualifierType, Type};
     use crate::common::ast::decl::Decl;
-    use crate::common::ast::expr::{Expr, Literal};
+    use crate::common::ast::expr::{Expr, Literal, MemberAccess};
     use crate::common::ast::stmt::Stmt;
     use crate::common::errors::error_data::Span;
     use crate::common::errors::types::SemanticErrorKind;
@@ -185,5 +185,44 @@ mod tests {
             .unwrap();
         let ty = analyser.analyse_expr(&ident("f"));
         assert!(matches!(ty.ty, crate::common::ast::ast::Type::Float));
+    }
+
+    #[test]
+    fn typedef_alias_resolves_before_member_access() {
+        let prog = Program {
+            decls: vec![
+                Decl::StructDecl(
+                    "Point".into(),
+                    vec![(qty(Type::Int), "x".into())],
+                    span(),
+                ),
+                Decl::Typedef(qty(Type::Struct("Point".into())), "PointAlias".into(), span()),
+                Decl::Function(
+                    qty(Type::Void),
+                    "main".into(),
+                    vec![],
+                    vec![
+                        Stmt::VarDecl(
+                            qty(Type::Alias("PointAlias".into())),
+                            "p".into(),
+                            None,
+                            span(),
+                        ),
+                        Stmt::ExprStmt(
+                            Expr::Member(
+                                Box::new(ident("p")),
+                                MemberAccess::Direct,
+                                "x".into(),
+                                span(),
+                            ),
+                            span(),
+                        ),
+                    ],
+                    span(),
+                ),
+            ],
+        };
+
+        assert!(analyse(&prog).is_empty());
     }
 }


### PR DESCRIPTION
## feat(parser): add enum and typedef support

## Descrição:
Este PR adiciona suporte mínimo e funcional para declarações `enum` e `typedef`, que antes eram rejeitadas pelo parser.

## Resumo das mudanças:
- O AST passou a representar `enum` e `typedef` com novas variantes de declaração.
- O parser agora aceita:
  - `enum Name { VARIANT = value, ... };`
  - `typedef <type> <alias>;`
- O parser mantém nomes de tipo conhecidos para permitir o uso de aliases em declarações posteriores.
- A análise semântica registra aliases de tipo e resolve esses aliases antes de declarar símbolos.
- Foram adicionados testes cobrindo parsing de `enum`, `typedef` e resolução de alias na semântica.

## Validação:
- `cargo test`