### PR TITLE
Feat(semantic): implementar travessia semântica 

### DIFF
--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -33,10 +33,19 @@ impl SemanticAnalyser {
     pub fn analyse_decl(&mut self, decl: &Decl) {
         match decl {
             Decl::GlobalVar(qty, name, init, span) => {
-                if let Some(expr) = init {
-                    self.analyse_expr(expr);
-                }
                 let resolved_qty = self.resolve_type(qty);
+                if let Some(expr) = init {
+                    let init_ty = self.analyse_expr(expr);
+                    if !types_compatible_for_assign(&resolved_qty.ty, &init_ty.ty) {
+                        self.diagnostics.push(CompilerError::Semantic(SemanticError {
+                            span: expr.span(),
+                            kind: SemanticErrorKind::TypeMismatch {
+                                expected: type_name(&resolved_qty.ty),
+                                found: type_name(&init_ty.ty),
+                            },
+                        }));
+                    }
+                }
                 let symbol = Symbol {
                     name: name.clone(),
                     ty: resolved_qty.clone(),
@@ -79,9 +88,20 @@ impl SemanticAnalyser {
                 let resolved_qty = self.resolve_type(qty);
                 self.sym.register_type_alias(name.clone(), resolved_qty);
             }
-            Decl::Function(return_type, _name, params, body, span) => {
+            Decl::Function(return_type, name, params, body, span) => {
+                let resolved_return_type = self.resolve_type(return_type);
+                let function_symbol = Symbol {
+                    name: name.clone(),
+                    ty: resolved_return_type.clone(),
+                    mutable: false,
+                    decl_span: span.clone(),
+                };
+                if let Err(e) = self.sym.declare(function_symbol) {
+                    self.diagnostics.push(e);
+                }
+
                 self.sym.enter_scope();
-                let prev_ret = self.current_fn_ret.replace(self.resolve_type(return_type));
+                let prev_ret = self.current_fn_ret.replace(resolved_return_type);
 
                 for (qty, name) in params {
                     let resolved_qty = self.resolve_type(qty);
@@ -134,9 +154,25 @@ impl SemanticAnalyser {
                 self.analyse_expr(expr);
             }
             Stmt::Return(expr, _) => {
-                if let Some(e) = expr {
-                    self.analyse_expr(e);
-                    // TODO(#87): checar compatibilidade com current_fn_ret
+                let ret_ty = expr
+                    .as_ref()
+                    .map(|e| self.analyse_expr(e))
+                    .unwrap_or_else(|| QualifierType {
+                        ty: Type::Void,
+                        is_const: false,
+                        is_unsigned: false,
+                    });
+
+                if let Some(expected_ret) = &self.current_fn_ret {
+                    if !types_compatible_for_assign(&expected_ret.ty, &ret_ty.ty) {
+                        self.diagnostics.push(CompilerError::Semantic(SemanticError {
+                            span: expr.as_ref().map(|e| e.span()).unwrap_or_else(|| stmt.span()),
+                            kind: SemanticErrorKind::TypeMismatch {
+                                expected: type_name(&expected_ret.ty),
+                                found: type_name(&ret_ty.ty),
+                            },
+                        }));
+                    }
                 }
             }
             Stmt::If(cond, then, else_, _) => {
@@ -255,12 +291,11 @@ impl SemanticAnalyser {
             }
             Expr::SizeofType(_, _) => uint_type(),
             Expr::Call(callee, args, _) => {
-                self.analyse_expr(callee);
+                let callee_ty = self.analyse_expr(callee);
                 for a in args {
                     self.analyse_expr(a);
                 }
-                // TODO(#87): lookup do tipo de retorno da função
-                unknown_type()
+                callee_ty
             }
             Expr::Index(arr, idx, _) => {
                 let arr_ty = self.analyse_expr(arr);

--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -37,13 +37,14 @@ impl SemanticAnalyser {
                 if let Some(expr) = init {
                     let init_ty = self.analyse_expr(expr);
                     if !types_compatible_for_assign(&resolved_qty.ty, &init_ty.ty) {
-                        self.diagnostics.push(CompilerError::Semantic(SemanticError {
-                            span: expr.span(),
-                            kind: SemanticErrorKind::TypeMismatch {
-                                expected: type_name(&resolved_qty.ty),
-                                found: type_name(&init_ty.ty),
-                            },
-                        }));
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: expr.span(),
+                                kind: SemanticErrorKind::TypeMismatch {
+                                    expected: type_name(&resolved_qty.ty),
+                                    found: type_name(&init_ty.ty),
+                                },
+                            }));
                     }
                 }
                 let symbol = Symbol {
@@ -165,13 +166,17 @@ impl SemanticAnalyser {
 
                 if let Some(expected_ret) = &self.current_fn_ret {
                     if !types_compatible_for_assign(&expected_ret.ty, &ret_ty.ty) {
-                        self.diagnostics.push(CompilerError::Semantic(SemanticError {
-                            span: expr.as_ref().map(|e| e.span()).unwrap_or_else(|| stmt.span()),
-                            kind: SemanticErrorKind::TypeMismatch {
-                                expected: type_name(&expected_ret.ty),
-                                found: type_name(&ret_ty.ty),
-                            },
-                        }));
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: expr
+                                    .as_ref()
+                                    .map(|e| e.span())
+                                    .unwrap_or_else(|| stmt.span()),
+                                kind: SemanticErrorKind::TypeMismatch {
+                                    expected: type_name(&expected_ret.ty),
+                                    found: type_name(&ret_ty.ty),
+                                },
+                            }));
                     }
                 }
             }

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -137,6 +137,25 @@ mod tests {
         assert!(analyse(&prog).is_empty());
     }
 
+    #[test]
+    fn global_initializer_type_mismatch_emits_error() {
+        let prog = Program {
+            decls: vec![Decl::GlobalVar(
+                qty(Type::Int),
+                "x".into(),
+                Some(Expr::Literal(Literal::String("hello".into()), span())),
+                span(),
+            )],
+        };
+
+        let errors = analyse(&prog);
+        assert!(errors.iter().any(|e| matches!(
+            e,
+            crate::common::errors::types::CompilerError::Semantic(se)
+                if matches!(&se.kind, SemanticErrorKind::TypeMismatch { .. })
+        )));
+    }
+
     // ── múltiplos erros acumulados ────────────────────────────────────────────
 
     #[test]
@@ -326,6 +345,24 @@ mod tests {
         let ty = analyser.analyse_expr(&expr);
         assert!(analyser.diagnostics.is_empty());
         assert!(matches!(ty.ty, Type::Int));
+    }
+
+    #[test]
+    fn function_call_uses_registered_return_type() {
+        let prog = Program {
+            decls: vec![Decl::Function(
+                qty(Type::Int),
+                "main".into(),
+                vec![],
+                vec![Stmt::Return(
+                    Some(Expr::Call(Box::new(ident("main")), vec![], span())),
+                    span(),
+                )],
+                span(),
+            )],
+        };
+
+        assert!(analyse(&prog).is_empty());
     }
 
     // ── Assign: verificação de compatibilidade de tipo ────────────────────────


### PR DESCRIPTION
## Contexto

As issues de tabela de símbolos e checagem de tipos já definem as bases do analisador semântico, mas ainda faltava a infraestrutura de travessia da AST que conecta essas peças.

O analisador semântico agora percorre a AST de forma sistemática, de `Program` até `Expr`, mantendo estado de escopo, tipo de retorno da função corrente e diagnósticos acumulados durante a análise.

## O que foi feito

- Implementação da travessia semântica da AST.
- Análise de declarações, comandos e expressões.
- Registro de funções, structs e aliases na tabela de símbolos.
- Verificação de tipos em inicializadores, atribuições e retornos.
- Exposição da API pública de análise semântica.
- Integração da análise no fluxo principal após o parse.

## Validação

- O programa de exemplo válido continua sem diagnósticos semânticos indevidos.
- Casos inválidos geram diagnósticos semânticos corretos.
- A suíte de testes permanece verde.

## Observações

Essa etapa fecha a ponte entre o parser e as regras semânticas, preparando o projeto para evoluções mais completas de verificação de tipos e uso de símbolos.