### PR TITLE
Feat(analyser): verificar chamadas de função (aridade, tipos e callable)

### DIFF
--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -51,6 +51,7 @@ impl SemanticAnalyser {
                     name: name.clone(),
                     ty: resolved_qty.clone(),
                     mutable: !resolved_qty.is_const,
+                    params: None,
                     decl_span: span.clone(),
                 };
                 if let Err(e) = self.sym.declare(symbol) {
@@ -74,6 +75,7 @@ impl SemanticAnalyser {
                             is_unsigned: false,
                         },
                         mutable: false,
+                        params: None,
                         decl_span: value
                             .as_ref()
                             .map(|expr| expr.span())
@@ -90,19 +92,26 @@ impl SemanticAnalyser {
                 self.sym.register_type_alias(name.clone(), resolved_qty);
             }
             Decl::Function(return_type, name, params, body, span) => {
-                let resolved_return_type = self.resolve_type(return_type);
+                let resolved_ret = self.resolve_type(return_type);
+                let param_tys: Vec<QualifierType> = params
+                    .iter()
+                    .map(|(qty, _)| self.resolve_type(qty))
+                    .collect();
+
                 let function_symbol = Symbol {
                     name: name.clone(),
-                    ty: resolved_return_type.clone(),
+                    ty: resolved_ret.clone(),
                     mutable: false,
+                    params: Some(param_tys.clone()),
                     decl_span: span.clone(),
                 };
+
                 if let Err(e) = self.sym.declare(function_symbol) {
                     self.diagnostics.push(e);
                 }
 
                 self.sym.enter_scope();
-                let prev_ret = self.current_fn_ret.replace(resolved_return_type);
+                let prev_ret = self.current_fn_ret.replace(resolved_ret);
 
                 for (qty, name) in params {
                     let resolved_qty = self.resolve_type(qty);
@@ -110,6 +119,7 @@ impl SemanticAnalyser {
                         name: name.clone(),
                         ty: resolved_qty.clone(),
                         mutable: !resolved_qty.is_const,
+                        params: None,
                         decl_span: span.clone(),
                     };
                     if let Err(e) = self.sym.declare(symbol) {
@@ -138,6 +148,7 @@ impl SemanticAnalyser {
                     name: name.clone(),
                     ty: resolved_qty.clone(),
                     mutable: !resolved_qty.is_const,
+                    params: None,
                     decl_span: span.clone(),
                 };
                 if let Err(e) = self.sym.declare(symbol) {
@@ -295,12 +306,81 @@ impl SemanticAnalyser {
                 uint_type()
             }
             Expr::SizeofType(_, _) => uint_type(),
-            Expr::Call(callee, args, _) => {
-                let callee_ty = self.analyse_expr(callee);
+            Expr::Call(callee, args, span) => {
+                if let Expr::Ident(name, id_span) = callee.as_ref() {
+                    match self.sym.lookup(name) {
+                        None => {
+                            self.diagnostics.push(CompilerError::Semantic(SemanticError {
+                                span: id_span.clone(),
+                                kind: SemanticErrorKind::UndefinedVariable(name.clone()),
+                            }));
+                            for a in args {
+                                self.analyse_expr(a);
+                            }
+                            return unknown_type();
+                        }
+                        Some(sym) => {
+                            let params_clone = sym.params.clone();
+                            let ret_ty_clone = sym.ty.clone();
+
+                            match params_clone {
+                                None => {
+                                    self.diagnostics.push(CompilerError::Semantic(SemanticError {
+                                        span: id_span.clone(),
+                                        kind: SemanticErrorKind::CallNonFunction(name.clone()),
+                                    }));
+                                    for a in args {
+                                        self.analyse_expr(a);
+                                    }
+                                    return unknown_type();
+                                }
+                                Some(param_types) => {
+                                    if param_types.len() != args.len() {
+                                        self.diagnostics.push(CompilerError::Semantic(
+                                            SemanticError {
+                                                span: span.clone(),
+                                                kind: SemanticErrorKind::ArityMismatch {
+                                                    expected: param_types.len(),
+                                                    found: args.len(),
+                                                },
+                                            },
+                                        ));
+                                    }
+
+                                    for (i, a) in args.iter().enumerate() {
+                                        let arg_ty = self.analyse_expr(a);
+                                        if i < param_types.len() {
+                                            let param_ty = &param_types[i];
+                                            if !types_compatible_for_assign(&param_ty.ty, &arg_ty.ty) {
+                                                self.diagnostics.push(CompilerError::Semantic(
+                                                    SemanticError {
+                                                        span: a.span(),
+                                                        kind: SemanticErrorKind::TypeMismatch {
+                                                            expected: type_name(&param_ty.ty),
+                                                            found: type_name(&arg_ty.ty),
+                                                        },
+                                                    },
+                                                ));
+                                            }
+                                        }
+                                    }
+
+                                    return QualifierType {
+                                        ty: ret_ty_clone.ty,
+                                        is_const: ret_ty_clone.is_const,
+                                        is_unsigned: ret_ty_clone.is_unsigned,
+                                    };
+                                }
+                            }
+                        }
+                    }
+                }
+
+                self.analyse_expr(callee);
                 for a in args {
                     self.analyse_expr(a);
                 }
-                callee_ty
+                unknown_type()
             }
             Expr::Index(arr, idx, _) => {
                 let arr_ty = self.analyse_expr(arr);

--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -310,10 +310,11 @@ impl SemanticAnalyser {
                 if let Expr::Ident(name, id_span) = callee.as_ref() {
                     match self.sym.lookup(name) {
                         None => {
-                            self.diagnostics.push(CompilerError::Semantic(SemanticError {
-                                span: id_span.clone(),
-                                kind: SemanticErrorKind::UndefinedVariable(name.clone()),
-                            }));
+                            self.diagnostics
+                                .push(CompilerError::Semantic(SemanticError {
+                                    span: id_span.clone(),
+                                    kind: SemanticErrorKind::UndefinedVariable(name.clone()),
+                                }));
                             for a in args {
                                 self.analyse_expr(a);
                             }
@@ -325,10 +326,11 @@ impl SemanticAnalyser {
 
                             match params_clone {
                                 None => {
-                                    self.diagnostics.push(CompilerError::Semantic(SemanticError {
-                                        span: id_span.clone(),
-                                        kind: SemanticErrorKind::CallNonFunction(name.clone()),
-                                    }));
+                                    self.diagnostics
+                                        .push(CompilerError::Semantic(SemanticError {
+                                            span: id_span.clone(),
+                                            kind: SemanticErrorKind::CallNonFunction(name.clone()),
+                                        }));
                                     for a in args {
                                         self.analyse_expr(a);
                                     }
@@ -351,7 +353,10 @@ impl SemanticAnalyser {
                                         let arg_ty = self.analyse_expr(a);
                                         if i < param_types.len() {
                                             let param_ty = &param_types[i];
-                                            if !types_compatible_for_assign(&param_ty.ty, &arg_ty.ty) {
+                                            if !types_compatible_for_assign(
+                                                &param_ty.ty,
+                                                &arg_ty.ty,
+                                            ) {
                                                 self.diagnostics.push(CompilerError::Semantic(
                                                     SemanticError {
                                                         span: a.span(),

--- a/src/analyser/symbol_table.rs
+++ b/src/analyser/symbol_table.rs
@@ -10,6 +10,8 @@ pub struct Symbol {
     pub name: String,
     pub ty: QualifierType,
     pub mutable: bool,
+    /// For functions, the parameter types (in order). `None` for non-functions.
+    pub params: Option<Vec<QualifierType>>,
     pub decl_span: Span,
 }
 

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -120,6 +120,11 @@ pub enum SemanticErrorKind {
         expected: String,
         found: String,
     },
+    ArityMismatch {
+        expected: usize,
+        found: usize,
+    },
+    CallNonFunction(String),
     UndefinedStruct(String),
     FieldNotFound {
         struct_name: String,
@@ -155,6 +160,17 @@ impl ToReport for SemanticError {
                     self.span.clone(),
                     format!("esperado: '{}', encontrado: '{}'", expected, found),
                 ),
+            SemanticErrorKind::ArityMismatch { expected, found } => {
+                Report::new("arity mismatch")
+                    .with_span(self.span.clone())
+                    .with_label(
+                        self.span.clone(),
+                        format!("expected {} args, found {}", expected, found),
+                    )
+            }
+            SemanticErrorKind::CallNonFunction(name) => Report::new("call on non-function")
+                .with_span(self.span.clone())
+                .with_label(self.span.clone(), format!("'{}' is not callable", name)),
             SemanticErrorKind::UndefinedStruct(name) => Report::new("undefined struct")
                 .with_span(self.span.clone())
                 .with_label(

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -160,14 +160,12 @@ impl ToReport for SemanticError {
                     self.span.clone(),
                     format!("esperado: '{}', encontrado: '{}'", expected, found),
                 ),
-            SemanticErrorKind::ArityMismatch { expected, found } => {
-                Report::new("arity mismatch")
-                    .with_span(self.span.clone())
-                    .with_label(
-                        self.span.clone(),
-                        format!("expected {} args, found {}", expected, found),
-                    )
-            }
+            SemanticErrorKind::ArityMismatch { expected, found } => Report::new("arity mismatch")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    format!("expected {} args, found {}", expected, found),
+                ),
             SemanticErrorKind::CallNonFunction(name) => Report::new("call on non-function")
                 .with_span(self.span.clone())
                 .with_label(self.span.clone(), format!("'{}' is not callable", name)),

--- a/src/tests/analyzer_test.rs
+++ b/src/tests/analyzer_test.rs
@@ -45,6 +45,7 @@ mod test {
                     is_unsigned: false,
                 },
                 mutable: true,
+                params: None,
                 decl_span: dummy_span(),
             })
             .unwrap();
@@ -78,6 +79,7 @@ mod test {
                     is_unsigned: false,
                 },
                 mutable: true,
+                params: None,
                 decl_span: dummy_span(),
             })
             .unwrap();
@@ -110,6 +112,7 @@ mod test {
                     is_unsigned: false,
                 },
                 mutable: true,
+                params: None,
                 decl_span: dummy_span(),
             })
             .unwrap();

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -498,12 +498,25 @@ mod tests {
     fn call_correct_is_ok() {
         let prog = Program {
             decls: vec![
-                Decl::Function(qty(Type::Int), "f".into(), vec![(qty(Type::Int), "a".into())], vec![], span()),
+                Decl::Function(
+                    qty(Type::Int),
+                    "f".into(),
+                    vec![(qty(Type::Int), "a".into())],
+                    vec![],
+                    span(),
+                ),
                 Decl::Function(
                     qty(Type::Void),
                     "main".into(),
                     vec![],
-                    vec![Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![int_lit(1)], span()), span())],
+                    vec![Stmt::ExprStmt(
+                        Expr::Call(
+                            Box::new(Expr::Ident("f".into(), span())),
+                            vec![int_lit(1)],
+                            span(),
+                        ),
+                        span(),
+                    )],
                     span(),
                 ),
             ],
@@ -515,12 +528,21 @@ mod tests {
     fn call_arity_mismatch_emits_error() {
         let prog = Program {
             decls: vec![
-                Decl::Function(qty(Type::Int), "f".into(), vec![(qty(Type::Int), "a".into())], vec![], span()),
+                Decl::Function(
+                    qty(Type::Int),
+                    "f".into(),
+                    vec![(qty(Type::Int), "a".into())],
+                    vec![],
+                    span(),
+                ),
                 Decl::Function(
                     qty(Type::Void),
                     "main".into(),
                     vec![],
-                    vec![Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![], span()), span())],
+                    vec![Stmt::ExprStmt(
+                        Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![], span()),
+                        span(),
+                    )],
                     span(),
                 ),
             ],
@@ -537,12 +559,25 @@ mod tests {
     fn call_arg_type_mismatch_emits_error() {
         let prog = Program {
             decls: vec![
-                Decl::Function(qty(Type::Int), "f".into(), vec![(qty(Type::Int), "a".into())], vec![], span()),
+                Decl::Function(
+                    qty(Type::Int),
+                    "f".into(),
+                    vec![(qty(Type::Int), "a".into())],
+                    vec![],
+                    span(),
+                ),
                 Decl::Function(
                     qty(Type::Void),
                     "main".into(),
                     vec![],
-                    vec![Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![Expr::Literal(Literal::String("hi".into()), span())], span()), span())],
+                    vec![Stmt::ExprStmt(
+                        Expr::Call(
+                            Box::new(Expr::Ident("f".into(), span())),
+                            vec![Expr::Literal(Literal::String("hi".into()), span())],
+                            span(),
+                        ),
+                        span(),
+                    )],
                     span(),
                 ),
             ],
@@ -558,18 +593,19 @@ mod tests {
     #[test]
     fn calling_variable_as_function_emits_error() {
         let prog = Program {
-            decls: vec![
-                Decl::Function(
-                    qty(Type::Void),
-                    "main".into(),
-                    vec![],
-                    vec![
-                        Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(1)), span()),
-                        Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("x".into(), span())), vec![], span()), span()),
-                    ],
-                    span(),
-                ),
-            ],
+            decls: vec![Decl::Function(
+                qty(Type::Void),
+                "main".into(),
+                vec![],
+                vec![
+                    Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(1)), span()),
+                    Stmt::ExprStmt(
+                        Expr::Call(Box::new(Expr::Ident("x".into(), span())), vec![], span()),
+                        span(),
+                    ),
+                ],
+                span(),
+            )],
         };
         let errors = analyse(&prog);
         assert!(errors.iter().any(|e| matches!(

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -199,6 +199,7 @@ mod tests {
                 name: "f".into(),
                 ty: qty(Type::Float),
                 mutable: true,
+                params: None,
                 decl_span: span(),
             })
             .unwrap();
@@ -248,6 +249,7 @@ mod tests {
                 name: "f".into(),
                 ty: qty(Type::Float),
                 mutable: true,
+                params: None,
                 decl_span: span(),
             })
             .unwrap();
@@ -272,6 +274,7 @@ mod tests {
                 name: "p".into(),
                 ty: qty(Type::Pointer(Box::new(Type::Int))),
                 mutable: true,
+                params: None,
                 decl_span: span(),
             })
             .unwrap();
@@ -487,5 +490,92 @@ mod tests {
         };
 
         assert!(analyse(&prog).is_empty());
+    }
+
+    // ── Call checks ───────────────────────────────────────────────────────
+
+    #[test]
+    fn call_correct_is_ok() {
+        let prog = Program {
+            decls: vec![
+                Decl::Function(qty(Type::Int), "f".into(), vec![(qty(Type::Int), "a".into())], vec![], span()),
+                Decl::Function(
+                    qty(Type::Void),
+                    "main".into(),
+                    vec![],
+                    vec![Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![int_lit(1)], span()), span())],
+                    span(),
+                ),
+            ],
+        };
+        assert!(analyse(&prog).is_empty());
+    }
+
+    #[test]
+    fn call_arity_mismatch_emits_error() {
+        let prog = Program {
+            decls: vec![
+                Decl::Function(qty(Type::Int), "f".into(), vec![(qty(Type::Int), "a".into())], vec![], span()),
+                Decl::Function(
+                    qty(Type::Void),
+                    "main".into(),
+                    vec![],
+                    vec![Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![], span()), span())],
+                    span(),
+                ),
+            ],
+        };
+        let errors = analyse(&prog);
+        assert!(errors.iter().any(|e| matches!(
+            e,
+            crate::common::errors::types::CompilerError::Semantic(se)
+                if matches!(&se.kind, crate::common::errors::types::SemanticErrorKind::ArityMismatch { .. })
+        )));
+    }
+
+    #[test]
+    fn call_arg_type_mismatch_emits_error() {
+        let prog = Program {
+            decls: vec![
+                Decl::Function(qty(Type::Int), "f".into(), vec![(qty(Type::Int), "a".into())], vec![], span()),
+                Decl::Function(
+                    qty(Type::Void),
+                    "main".into(),
+                    vec![],
+                    vec![Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("f".into(), span())), vec![Expr::Literal(Literal::String("hi".into()), span())], span()), span())],
+                    span(),
+                ),
+            ],
+        };
+        let errors = analyse(&prog);
+        assert!(errors.iter().any(|e| matches!(
+            e,
+            crate::common::errors::types::CompilerError::Semantic(se)
+                if matches!(&se.kind, crate::common::errors::types::SemanticErrorKind::TypeMismatch { .. })
+        )));
+    }
+
+    #[test]
+    fn calling_variable_as_function_emits_error() {
+        let prog = Program {
+            decls: vec![
+                Decl::Function(
+                    qty(Type::Void),
+                    "main".into(),
+                    vec![],
+                    vec![
+                        Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(1)), span()),
+                        Stmt::ExprStmt(Expr::Call(Box::new(Expr::Ident("x".into(), span())), vec![], span()), span()),
+                    ],
+                    span(),
+                ),
+            ],
+        };
+        let errors = analyse(&prog);
+        assert!(errors.iter().any(|e| matches!(
+            e,
+            crate::common::errors::types::CompilerError::Semantic(se)
+                if matches!(&se.kind, crate::common::errors::types::SemanticErrorKind::CallNonFunction(_))
+        )));
     }
 }

--- a/src/tests/symbol_test.rs
+++ b/src/tests/symbol_test.rs
@@ -26,6 +26,7 @@ mod tests {
                 is_unsigned: false,
             },
             mutable: !is_const,
+            params: None,
             decl_span: span(),
         }
     }


### PR DESCRIPTION
## feat(analyser): verificar chamadas de função (aridade, tipos e callable)

## Resumo

Implementa verificações semânticas para chamadas de função e toda a infraestrutura relacionada solicitada na issue: registro de assinaturas de funções, validação de chamadas (existência, se é uma função, aridade correta e compatibilidade dos tipos dos argumentos), além da adição de novos tipos de erro e testes.

## O que foi alterado

### Analisador semântico

* Percorre a AST (`Program → Decl → Stmt → Expr`)
* Registra funções com os tipos de seus parâmetros
* Implementa verificações para `Expr::Call`:

  * função indefinida
  * chamada em algo que não é função
  * incompatibilidade de aridade
  * verificação de tipos argumento por argumento
* Propaga corretamente o tipo de retorno das chamadas

### Tabela de símbolos

* Adicionado `params: Option<Vec<QualifierType>>` em `Symbol` para armazenar os tipos dos parâmetros de funções

### Erros semânticos

* Adicionados `ArityMismatch` e `CallNonFunction` em `SemanticErrorKind`
* Implementadas mensagens de erro renderizáveis para ambos

### Testes

Adicionados testes para:

* chamada correta de função
* incompatibilidade de aridade
* incompatibilidade de tipos dos argumentos
* chamada de variável que não é função

Também foram atualizados helpers e construções de testes para incluir o novo campo `params` quando necessário.

## Motivação

Essas alterações resolvem a issue ao garantir a correção das chamadas de função durante a análise semântica e melhorar os diagnósticos para erros comuns relacionados a chamadas.

## Testes executados

* Adicionados testes unitários e executada toda a suíte:

  * `cargo test` → todos os testes passaram (`169 passed`)
* Formatação verificada com:

  * `cargo fmt --check`

## Migração / Observações para revisores

* `Symbol` agora contém `params: Option<Vec<QualifierType>>`
* Qualquer construção direta de `Symbol` deve incluir `params`
* Novos erros semânticos podem ser emitidos:

  * `CallNonFunction`
  * `ArityMismatch`
* Ferramentas que fazem correspondência em `SemanticErrorKind` podem precisar de atualização

## Pendências / Próximos passos

* Expressão de índice:

  * implementar desreferenciamento adequado de arrays/pointers para `Expr::Index` (TODO)

* Expressão ternária:

  * implementar verificações completas de compatibilidade para `Expr::Ternary` (TODO)

# Checklist

* [x] Registrar assinaturas de funções antes da análise dos corpos
* [x] Verificar se o alvo da chamada existe e é chamável
* [x] Verificar aridade e tipos dos argumentos
* [x] Adicionar variantes de erro e mensagens para o usuário
* [x] Adicionar testes unitários e executar `cargo test` / `cargo fmt --check`
