### PR TITLE
feat(semantic): adicionar validacao de return em funcoes e erro Retur…

### DIFF
--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -165,30 +165,42 @@ impl SemanticAnalyser {
             Stmt::ExprStmt(expr, _) => {
                 self.analyse_expr(expr);
             }
-            Stmt::Return(expr, _) => {
-                let ret_ty = expr
-                    .as_ref()
-                    .map(|e| self.analyse_expr(e))
-                    .unwrap_or_else(|| QualifierType {
-                        ty: Type::Void,
-                        is_const: false,
-                        is_unsigned: false,
-                    });
+            Stmt::Return(expr, span) => {
+                let expected_fn_type = self.current_fn_ret.clone();
 
-                if let Some(expected_ret) = &self.current_fn_ret {
-                    if !types_compatible_for_assign(&expected_ret.ty, &ret_ty.ty) {
+                match (expected_fn_type, expr) {
+                    (Some(expected), Some(e)) if expected.ty == Type::Void => {
+                        self.analyse_expr(e);
                         self.diagnostics
                             .push(CompilerError::Semantic(SemanticError {
-                                span: expr
-                                    .as_ref()
-                                    .map(|e| e.span())
-                                    .unwrap_or_else(|| stmt.span()),
+                                span: span.clone(),
+                                kind: SemanticErrorKind::ReturnInVoid,
+                            }));
+                    }
+                    (Some(expected), Some(e)) => {
+                        let found_expr_qty = self.analyse_expr(e);
+                        if expected.ty != found_expr_qty.ty {
+                            self.diagnostics
+                                .push(CompilerError::Semantic(SemanticError {
+                                    span: span.clone(),
+                                    kind: SemanticErrorKind::TypeMismatch {
+                                        expected: type_name(&expected.ty),
+                                        found: type_name(&found_expr_qty.ty),
+                                    },
+                                }));
+                        }
+                    }
+                    (Some(expected), None) if expected.ty != Type::Void => {
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: span.clone(),
                                 kind: SemanticErrorKind::TypeMismatch {
-                                    expected: type_name(&expected_ret.ty),
-                                    found: type_name(&ret_ty.ty),
+                                    expected: type_name(&expected.ty),
+                                    found: "void (retorno vazio)".to_string(),
                                 },
                             }));
                     }
+                    _ => {}
                 }
             }
             Stmt::If(cond, then, else_, _) => {

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -116,6 +116,7 @@ impl ToReport for SyntaxError {
 pub enum SemanticErrorKind {
     UndefinedVariable(String),
     Redeclaration(String),
+    ReturnInVoid,
     TypeMismatch {
         expected: String,
         found: String,
@@ -154,6 +155,12 @@ impl ToReport for SemanticError {
                     format!("'{}' já foi declarado neste escopo", name),
                 )
                 .with_help("use um nome diferente ou remova a declaração duplicada"),
+            SemanticErrorKind::ReturnInVoid => Report::new("return in void function")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    "função void não pode retornar um valor".to_string(),
+                ),
             SemanticErrorKind::TypeMismatch { expected, found } => Report::new("type error")
                 .with_span(self.span.clone())
                 .with_label(

--- a/src/tests/analyzer_test.rs
+++ b/src/tests/analyzer_test.rs
@@ -3,8 +3,11 @@ mod test {
     use crate::analyser::symbol_table::Symbol;
     use crate::analyser::SemanticAnalyser;
     use crate::common::ast::ast::{QualifierType, Type};
-    use crate::common::ast::expr::{Expr, MemberAccess};
+    use crate::common::ast::decl::Decl;
+    use crate::common::ast::expr::{Expr, Literal, MemberAccess};
+    use crate::common::ast::stmt::Stmt;
     use crate::common::errors::error_data::Span;
+    use crate::common::errors::types::SemanticErrorKind;
 
     fn dummy_span() -> Span {
         Span {
@@ -131,5 +134,139 @@ mod test {
             "deveria aceitar acesso via ponteiro"
         );
         assert_eq!(ty.ty, Type::Int);
+    }
+
+    #[test]
+    fn test_return_type_mismatch_error() {
+        let mut analyser = SemanticAnalyser::new();
+        let span = dummy_span();
+
+        let ret_type = QualifierType {
+            ty: Type::Int,
+            is_const: false,
+            is_unsigned: false,
+        };
+
+        let expr_errada = Expr::Literal(Literal::Double(2.5), span.clone());
+        let stmt_return = Stmt::Return(Some(expr_errada), span.clone());
+
+        let funcao_ast = Decl::Function(
+            ret_type,
+            "minha_funcao".to_string(),
+            vec![],
+            vec![stmt_return],
+            span,
+        );
+
+        analyser.sym.enter_scope();
+        analyser.analyse_decl(&funcao_ast);
+        analyser.sym.exit_scope();
+
+        assert_eq!(
+            analyser.diagnostics.len(),
+            1,
+            "Deveria ter detectado incopatibilidade: Int x Double."
+        );
+    }
+
+    #[test]
+    fn test_empty_return_in_non_void_error() {
+        let mut analyser = SemanticAnalyser::new();
+        let span = dummy_span();
+
+        let ret_type = QualifierType {
+            ty: Type::Int,
+            is_const: false,
+            is_unsigned: false,
+        };
+
+        let stmt_return = Stmt::Return(None, span.clone());
+
+        let funcao_ast = Decl::Function(
+            ret_type,
+            "minha_funcao".to_string(),
+            vec![],
+            vec![stmt_return],
+            span,
+        );
+
+        analyser.sym.enter_scope();
+        analyser.analyse_decl(&funcao_ast);
+        analyser.sym.exit_scope();
+
+        assert_eq!(
+            analyser.diagnostics.len(),
+            1,
+            "Deveria ter detectado um retorno vazio em uma função int."
+        );
+    }
+
+    #[test]
+    fn test_valid_return_success() {
+        let mut analyser = SemanticAnalyser::new();
+        let span = dummy_span();
+
+        let ret_type = QualifierType {
+            ty: Type::Int,
+            is_const: false,
+            is_unsigned: false,
+        };
+
+        let expr_correta = Expr::Literal(Literal::Int(10), span.clone());
+        let stmt_return = Stmt::Return(Some(expr_correta), span.clone());
+
+        let funcao_ast = Decl::Function(
+            ret_type,
+            "minha_funcao".to_string(),
+            vec![],
+            vec![stmt_return],
+            span,
+        );
+
+        analyser.sym.enter_scope();
+        analyser.analyse_decl(&funcao_ast);
+        analyser.sym.exit_scope();
+
+        assert_eq!(
+            analyser.diagnostics.len(),
+            0,
+            "Não deveria ter detectado erro em um retorno válido"
+        );
+    }
+
+    #[test]
+    fn test_return_in_void_function_error() {
+        let mut analyser = SemanticAnalyser::new();
+        let span = dummy_span();
+
+        let ret_type = QualifierType {
+            ty: Type::Void,
+            is_const: false,
+            is_unsigned: false,
+        };
+
+        let expr = Expr::Literal(Literal::Int(10), span.clone());
+        let stmt_return = Stmt::Return(Some(expr), span.clone());
+
+        let funcao_ast = Decl::Function(
+            ret_type,
+            "minha_funcao_void".to_string(),
+            vec![],
+            vec![stmt_return],
+            span,
+        );
+
+        analyser.sym.enter_scope();
+        analyser.analyse_decl(&funcao_ast);
+        analyser.sym.exit_scope();
+
+        assert!(
+            analyser.diagnostics.iter().any(|error| matches!(
+                &error,
+                crate::common::errors::types::CompilerError::Semantic(se)
+                    if matches!(se.kind, SemanticErrorKind::ReturnInVoid)
+            )),
+            "deveria sinalizar retorno com valor em função void"
+        );
     }
 }


### PR DESCRIPTION
## Resumo
Este PR ajusta o analisador semântico para rastrear o tipo de retorno esperado durante a análise do corpo de funções e validar corretamente os `return`.

## O que mudou
- O analisador passa a manter `current_fn_ret: Option<QualifierType>` enquanto analisa uma função.
- `Stmt::Return(Some(expr))` em função `void` agora gera `SemanticErrorKind::ReturnInVoid`.
- `Stmt::Return(Some(expr))` com tipo incompatível com o retorno esperado gera `TypeMismatch`.
- `Stmt::Return(None)` em função não-void continua sendo reportado como erro.
- Foram adicionados testes cobrindo:
  - retorno válido
  - retorno com tipo incompatível
  - retorno vazio em função não-void
  - retorno com valor em função void

## Validação
- `cargo test`
<img width="686" height="23" alt="image" src="https://github.com/user-attachments/assets/71126e62-f99e-41fd-9ef9-b0979d06b19a" />

<img width="596" height="25" alt="image" src="https://github.com/user-attachments/assets/f04c64e5-ea69-4535-b7a7-ae03a2f7a491" />

<img width="686" height="23" alt="image" src="https://github.com/user-attachments/assets/19ee212d-aa06-4372-8279-47f62eaa0140" />


<img width="659" height="23" alt="image" src="https://github.com/user-attachments/assets/d5f7a875-6a73-4a8b-b21c-97ab8d078b53" />
