### PR TITLE
feat(cli): flags de diagnóstico --dump-tokens, --dump-ast, --dump-ir e --only-*

### DIFF
--- a/src/common/ast/mod.rs
+++ b/src/common/ast/mod.rs
@@ -3,4 +3,5 @@
 pub mod ast;
 pub mod decl;
 pub mod expr;
+pub mod pretty;
 pub mod stmt;

--- a/src/common/ast/pretty.rs
+++ b/src/common/ast/pretty.rs
@@ -362,11 +362,7 @@ fn fmt_type(ty: &Type) -> String {
         Type::Enum(n) => format!("enum {}", n),
         Type::Alias(n) => n.clone(),
         Type::Function(ret, params) => {
-            let params_str = params
-                .iter()
-                .map(fmt_qty)
-                .collect::<Vec<_>>()
-                .join(", ");
+            let params_str = params.iter().map(fmt_qty).collect::<Vec<_>>().join(", ");
             format!("fn({}) -> {}", params_str, fmt_qty(ret))
         }
     }

--- a/src/common/ast/pretty.rs
+++ b/src/common/ast/pretty.rs
@@ -364,7 +364,7 @@ fn fmt_type(ty: &Type) -> String {
         Type::Function(ret, params) => {
             let params_str = params
                 .iter()
-                .map(|p| fmt_qty(p))
+                .map(fmt_qty)
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("fn({}) -> {}", params_str, fmt_qty(ret))

--- a/src/common/ast/pretty.rs
+++ b/src/common/ast/pretty.rs
@@ -1,0 +1,369 @@
+use crate::common::ast::{
+    ast::{Program, QualifierType, Type},
+    decl::Decl,
+    expr::{BinOp, Expr, Literal, MemberAccess, PostfixOp, PrefixOp, UnOp},
+    stmt::{Stmt, SwitchLabel},
+};
+
+pub fn pretty_program(program: &Program) -> String {
+    let mut out = String::from("Program\n");
+    let n = program.decls.len();
+    for (i, decl) in program.decls.iter().enumerate() {
+        fmt_decl(&mut out, decl, "", i == n - 1);
+    }
+    out
+}
+
+fn branch(prefix: &str, is_last: bool) -> (&'static str, String) {
+    if is_last {
+        ("└── ", format!("{}    ", prefix))
+    } else {
+        ("├── ", format!("{}│   ", prefix))
+    }
+}
+
+fn fmt_decl(out: &mut String, decl: &Decl, prefix: &str, is_last: bool) {
+    let (conn, child_pfx) = branch(prefix, is_last);
+    match decl {
+        Decl::Function(ret, name, params, body, _) => {
+            let params_str = if params.is_empty() {
+                "[]".into()
+            } else {
+                let p: Vec<_> = params
+                    .iter()
+                    .map(|(qty, n)| format!("{} {}", fmt_qty(qty), n))
+                    .collect();
+                format!("[{}]", p.join(", "))
+            };
+            out.push_str(&format!(
+                "{}{}FunctionDecl({} {}, params={})\n",
+                prefix,
+                conn,
+                fmt_qty(ret),
+                name,
+                params_str
+            ));
+            let m = body.len();
+            for (j, stmt) in body.iter().enumerate() {
+                fmt_stmt(out, stmt, &child_pfx, j == m - 1);
+            }
+        }
+        Decl::GlobalVar(qty, name, init, _) => {
+            if let Some(expr) = init {
+                out.push_str(&format!(
+                    "{}{}GlobalVar({} {} =)\n",
+                    prefix,
+                    conn,
+                    fmt_qty(qty),
+                    name
+                ));
+                fmt_expr(out, expr, &child_pfx, true);
+            } else {
+                out.push_str(&format!(
+                    "{}{}GlobalVar({} {})\n",
+                    prefix,
+                    conn,
+                    fmt_qty(qty),
+                    name
+                ));
+            }
+        }
+        Decl::StructDecl(name, fields, _) => {
+            out.push_str(&format!("{}{}StructDecl({})\n", prefix, conn, name));
+            let m = fields.len();
+            for (j, (qty, fname)) in fields.iter().enumerate() {
+                let (fc, _) = branch(&child_pfx, j == m - 1);
+                out.push_str(&format!(
+                    "{}{}Field({} {})\n",
+                    child_pfx,
+                    fc,
+                    fmt_qty(qty),
+                    fname
+                ));
+            }
+        }
+        Decl::EnumDecl(name, variants, _) => {
+            out.push_str(&format!("{}{}EnumDecl({})\n", prefix, conn, name));
+            let m = variants.len();
+            for (j, (vname, val)) in variants.iter().enumerate() {
+                let (vc, vc_pfx) = branch(&child_pfx, j == m - 1);
+                if let Some(expr) = val {
+                    out.push_str(&format!("{}{}Variant({} =)\n", child_pfx, vc, vname));
+                    fmt_expr(out, expr, &vc_pfx, true);
+                } else {
+                    out.push_str(&format!("{}{}Variant({})\n", child_pfx, vc, vname));
+                }
+            }
+        }
+        Decl::Typedef(qty, name, _) => {
+            out.push_str(&format!(
+                "{}{}Typedef({} = {})\n",
+                prefix,
+                conn,
+                name,
+                fmt_qty(qty)
+            ));
+        }
+    }
+}
+
+fn fmt_stmt(out: &mut String, stmt: &Stmt, prefix: &str, is_last: bool) {
+    let (conn, child_pfx) = branch(prefix, is_last);
+    match stmt {
+        Stmt::VarDecl(qty, name, init, _) => {
+            if let Some(expr) = init {
+                out.push_str(&format!(
+                    "{}{}VarDecl({} {} =)\n",
+                    prefix,
+                    conn,
+                    fmt_qty(qty),
+                    name
+                ));
+                fmt_expr(out, expr, &child_pfx, true);
+            } else {
+                out.push_str(&format!(
+                    "{}{}VarDecl({} {})\n",
+                    prefix,
+                    conn,
+                    fmt_qty(qty),
+                    name
+                ));
+            }
+        }
+        Stmt::ExprStmt(expr, _) => {
+            out.push_str(&format!("{}{}ExprStmt\n", prefix, conn));
+            fmt_expr(out, expr, &child_pfx, true);
+        }
+        Stmt::Return(expr, _) => {
+            out.push_str(&format!("{}{}Return\n", prefix, conn));
+            if let Some(e) = expr {
+                fmt_expr(out, e, &child_pfx, true);
+            }
+        }
+        Stmt::Block(stmts, _) => {
+            out.push_str(&format!("{}{}Block\n", prefix, conn));
+            let m = stmts.len();
+            for (j, s) in stmts.iter().enumerate() {
+                fmt_stmt(out, s, &child_pfx, j == m - 1);
+            }
+        }
+        Stmt::If(cond, then, else_, _) => {
+            out.push_str(&format!("{}{}If\n", prefix, conn));
+            let has_else = else_.is_some();
+            fmt_expr(out, cond, &child_pfx, false);
+            if has_else {
+                fmt_stmt(out, then, &child_pfx, false);
+                fmt_stmt(out, else_.as_ref().unwrap(), &child_pfx, true);
+            } else {
+                fmt_stmt(out, then, &child_pfx, true);
+            }
+        }
+        Stmt::While(cond, body, _) => {
+            out.push_str(&format!("{}{}While\n", prefix, conn));
+            fmt_expr(out, cond, &child_pfx, false);
+            fmt_stmt(out, body, &child_pfx, true);
+        }
+        Stmt::DoWhile(cond, body, _) => {
+            out.push_str(&format!("{}{}DoWhile\n", prefix, conn));
+            fmt_stmt(out, body, &child_pfx, false);
+            fmt_expr(out, cond, &child_pfx, true);
+        }
+        Stmt::For(init, cond, inc, body, _) => {
+            out.push_str(&format!("{}{}For\n", prefix, conn));
+            let children_count =
+                init.is_some() as usize + cond.is_some() as usize + inc.is_some() as usize + 1;
+            let mut remaining = children_count;
+            if let Some(s) = init {
+                remaining -= 1;
+                fmt_stmt(out, s, &child_pfx, remaining == 0);
+            }
+            if let Some(e) = cond {
+                remaining -= 1;
+                fmt_expr(out, e, &child_pfx, remaining == 0);
+            }
+            if let Some(e) = inc {
+                remaining -= 1;
+                fmt_expr(out, e, &child_pfx, remaining == 0);
+            }
+            fmt_stmt(out, body, &child_pfx, true);
+        }
+        Stmt::Switch(expr, cases, _) => {
+            out.push_str(&format!("{}{}Switch\n", prefix, conn));
+            fmt_expr(out, expr, &child_pfx, cases.is_empty());
+            let m = cases.len();
+            for (j, case) in cases.iter().enumerate() {
+                let (cc, cc_pfx) = branch(&child_pfx, j == m - 1);
+                match &case.label {
+                    SwitchLabel::Case(e) => {
+                        out.push_str(&format!("{}{}Case\n", child_pfx, cc));
+                        fmt_expr(out, e, &cc_pfx, case.stmts.is_empty());
+                    }
+                    SwitchLabel::Default => {
+                        out.push_str(&format!("{}{}Default\n", child_pfx, cc));
+                    }
+                }
+                let sm = case.stmts.len();
+                for (k, s) in case.stmts.iter().enumerate() {
+                    fmt_stmt(out, s, &cc_pfx, k == sm - 1);
+                }
+            }
+        }
+        Stmt::Break(_) => out.push_str(&format!("{}{}Break\n", prefix, conn)),
+        Stmt::Continue(_) => out.push_str(&format!("{}{}Continue\n", prefix, conn)),
+    }
+}
+
+fn fmt_expr(out: &mut String, expr: &Expr, prefix: &str, is_last: bool) {
+    let (conn, child_pfx) = branch(prefix, is_last);
+    match expr {
+        Expr::Literal(lit, _) => {
+            let s = match lit {
+                Literal::Int(v) => format!("Literal(Int({}))", v),
+                Literal::Double(v) => format!("Literal(Double({}))", v),
+                Literal::Char(c) => format!("Literal(Char({:?}))", c),
+                Literal::String(s) => format!("Literal(String({:?}))", s),
+            };
+            out.push_str(&format!("{}{}{}\n", prefix, conn, s));
+        }
+        Expr::Ident(name, _) => {
+            out.push_str(&format!("{}{}Ident({})\n", prefix, conn, name));
+        }
+        Expr::Binary(lhs, op, rhs, _) => {
+            out.push_str(&format!("{}{}Binary({})\n", prefix, conn, fmt_binop(op)));
+            fmt_expr(out, lhs, &child_pfx, false);
+            fmt_expr(out, rhs, &child_pfx, true);
+        }
+        Expr::Unary(op, operand, _) => {
+            let s = match op {
+                UnOp::Neg => "Unary(-)",
+                UnOp::Not => "Unary(!)",
+                UnOp::BitNot => "Unary(~)",
+                UnOp::Deref => "Unary(*)",
+                UnOp::AddrOf => "Unary(&)",
+            };
+            out.push_str(&format!("{}{}{}\n", prefix, conn, s));
+            fmt_expr(out, operand, &child_pfx, true);
+        }
+        Expr::Prefix(op, operand, _) => {
+            let s = match op {
+                PrefixOp::Inc => "Prefix(++)",
+                PrefixOp::Dec => "Prefix(--)",
+            };
+            out.push_str(&format!("{}{}{}\n", prefix, conn, s));
+            fmt_expr(out, operand, &child_pfx, true);
+        }
+        Expr::Postfix(op, operand, _) => {
+            let s = match op {
+                PostfixOp::Inc => "Postfix(++)",
+                PostfixOp::Dec => "Postfix(--)",
+            };
+            out.push_str(&format!("{}{}{}\n", prefix, conn, s));
+            fmt_expr(out, operand, &child_pfx, true);
+        }
+        Expr::Call(callee, args, _) => {
+            out.push_str(&format!("{}{}Call\n", prefix, conn));
+            fmt_expr(out, callee, &child_pfx, args.is_empty());
+            let m = args.len();
+            for (j, arg) in args.iter().enumerate() {
+                fmt_expr(out, arg, &child_pfx, j == m - 1);
+            }
+        }
+        Expr::Cast(qty, expr, _) => {
+            out.push_str(&format!("{}{}Cast({})\n", prefix, conn, fmt_qty(qty)));
+            fmt_expr(out, expr, &child_pfx, true);
+        }
+        Expr::Index(arr, idx, _) => {
+            out.push_str(&format!("{}{}Index\n", prefix, conn));
+            fmt_expr(out, arr, &child_pfx, false);
+            fmt_expr(out, idx, &child_pfx, true);
+        }
+        Expr::Assign(lhs, rhs, _) => {
+            out.push_str(&format!("{}{}Assign\n", prefix, conn));
+            fmt_expr(out, lhs, &child_pfx, false);
+            fmt_expr(out, rhs, &child_pfx, true);
+        }
+        Expr::CompoundAssign(op, lhs, rhs, _) => {
+            out.push_str(&format!(
+                "{}{}CompoundAssign({}=)\n",
+                prefix,
+                conn,
+                fmt_binop(op)
+            ));
+            fmt_expr(out, lhs, &child_pfx, false);
+            fmt_expr(out, rhs, &child_pfx, true);
+        }
+        Expr::Sizeof(inner, _) => {
+            out.push_str(&format!("{}{}Sizeof\n", prefix, conn));
+            fmt_expr(out, inner, &child_pfx, true);
+        }
+        Expr::SizeofType(qty, _) => {
+            out.push_str(&format!("{}{}SizeofType({})\n", prefix, conn, fmt_qty(qty)));
+        }
+        Expr::Ternary(cond, then, else_, _) => {
+            out.push_str(&format!("{}{}Ternary\n", prefix, conn));
+            fmt_expr(out, cond, &child_pfx, false);
+            fmt_expr(out, then, &child_pfx, false);
+            fmt_expr(out, else_, &child_pfx, true);
+        }
+        Expr::Member(obj, access, field, _) => {
+            let op = match access {
+                MemberAccess::Direct => ".",
+                MemberAccess::Pointer => "->",
+            };
+            out.push_str(&format!("{}{}Member({}{})\n", prefix, conn, op, field));
+            fmt_expr(out, obj, &child_pfx, true);
+        }
+    }
+}
+
+fn fmt_qty(qty: &QualifierType) -> String {
+    let mut s = String::new();
+    if qty.is_const {
+        s.push_str("const ");
+    }
+    if qty.is_unsigned {
+        s.push_str("unsigned ");
+    }
+    s.push_str(&fmt_type(&qty.ty));
+    s
+}
+
+fn fmt_type(ty: &Type) -> String {
+    match ty {
+        Type::Int => "int".into(),
+        Type::Long => "long".into(),
+        Type::Short => "short".into(),
+        Type::Char => "char".into(),
+        Type::Float => "float".into(),
+        Type::Double => "double".into(),
+        Type::Void => "void".into(),
+        Type::Pointer(inner) => format!("{}*", fmt_type(inner)),
+        Type::Array(inner) => format!("{}[]", fmt_type(inner)),
+        Type::Struct(n) => format!("struct {}", n),
+        Type::Enum(n) => format!("enum {}", n),
+        Type::Alias(n) => n.clone(),
+    }
+}
+
+fn fmt_binop(op: &BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+        BinOp::Mod => "%",
+        BinOp::Eq => "==",
+        BinOp::Neq => "!=",
+        BinOp::Less => "<",
+        BinOp::Greater => ">",
+        BinOp::Leq => "<=",
+        BinOp::Geq => ">=",
+        BinOp::And => "&&",
+        BinOp::Or => "||",
+        BinOp::BitAnd => "&",
+        BinOp::BitOr => "|",
+        BinOp::BitXor => "^",
+        BinOp::Shl => "<<",
+        BinOp::Shr => ">>",
+    }
+}

--- a/src/common/ast/pretty.rs
+++ b/src/common/ast/pretty.rs
@@ -104,6 +104,25 @@ fn fmt_decl(out: &mut String, decl: &Decl, prefix: &str, is_last: bool) {
                 fmt_qty(qty)
             ));
         }
+        Decl::Prototype(ret, name, params, _) => {
+            let params_str = if params.is_empty() {
+                "[]".into()
+            } else {
+                let p: Vec<_> = params
+                    .iter()
+                    .map(|(qty, n)| format!("{} {}", fmt_qty(qty), n))
+                    .collect();
+                format!("[{}]", p.join(", "))
+            };
+            out.push_str(&format!(
+                "{}{}Prototype({} {}, params={})\n",
+                prefix,
+                conn,
+                fmt_qty(ret),
+                name,
+                params_str
+            ));
+        }
     }
 }
 
@@ -342,6 +361,14 @@ fn fmt_type(ty: &Type) -> String {
         Type::Struct(n) => format!("struct {}", n),
         Type::Enum(n) => format!("enum {}", n),
         Type::Alias(n) => n.clone(),
+        Type::Function(ret, params) => {
+            let params_str = params
+                .iter()
+                .map(|p| fmt_qty(p))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("fn({}) -> {}", params_str, fmt_qty(ret))
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use crusty::analyser::analyse;
+use crusty::common::ast::pretty::pretty_program;
 use crusty::common::errors::report::{Report, ToReport};
 use crusty::common::input::source::SourceFile;
 use crusty::lexer::scanner::Scanner;
@@ -7,29 +8,76 @@ use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 
-/// Ponto de entrada: decide entre modo interativo (sem args) ou compilação de arquivo (1 arg).
 fn main() -> std::io::Result<()> {
-    let args: Vec<_> = env::args().collect();
-    match args.len() {
-        1 => {
-            if let Err(e) = run_prompt() {
-                report_and_exit(e);
-            }
-        }
-        2 => {
-            if let Err(e) = run_file(&args[1]) {
-                report_and_exit(e);
-            }
-        }
-        _ => {
-            eprintln!("Usage: crusty [script]");
+    let raw: Vec<_> = env::args().collect();
+    let args = CliArgs::parse(&raw);
+
+    let file = match &args.input_file {
+        Some(f) => f.clone(),
+        None => {
+            eprintln!("Usage: crusty [flags] <file>");
+            eprintln!("Flags:");
+            eprintln!("  --dump-tokens      List all tokens emitted by the lexer");
+            eprintln!("  --dump-ast         Pretty-print the AST");
+            eprintln!("  --dump-ir          Dump TAC IR (not yet implemented)");
+            eprintln!("  --only-lex         Stop after lexing");
+            eprintln!("  --only-parse       Stop after parsing");
+            eprintln!("  --only-semantic    Stop after semantic analysis");
             exit(64);
         }
+    };
+
+    let source = match SourceFile::from_path(PathBuf::from(&file)) {
+        Ok(s) => s,
+        Err(e) => report_and_exit(e),
+    };
+
+    if let Err(e) = run(source, &args) {
+        report_and_exit(e);
     }
     Ok(())
 }
 
-/// Erro retornado por `run()` quando o scanner produz diagnósticos.
+// ── CLI arg parsing ──────────────────────────────────────────────────────────
+
+struct CliArgs {
+    input_file: Option<String>,
+    dump_tokens: bool,
+    dump_ast: bool,
+    dump_ir: bool,
+    only_lex: bool,
+    only_parse: bool,
+    only_semantic: bool,
+}
+
+impl CliArgs {
+    fn parse(args: &[String]) -> Self {
+        let mut cli = CliArgs {
+            input_file: None,
+            dump_tokens: false,
+            dump_ast: false,
+            dump_ir: false,
+            only_lex: false,
+            only_parse: false,
+            only_semantic: false,
+        };
+        for arg in args.iter().skip(1) {
+            match arg.as_str() {
+                "--dump-tokens" => cli.dump_tokens = true,
+                "--dump-ast" => cli.dump_ast = true,
+                "--dump-ir" => cli.dump_ir = true,
+                "--only-lex" => cli.only_lex = true,
+                "--only-parse" => cli.only_parse = true,
+                "--only-semantic" => cli.only_semantic = true,
+                _ => cli.input_file = Some(arg.clone()),
+            }
+        }
+        cli
+    }
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
 #[derive(Debug)]
 struct DiagnosticError {
     count: usize,
@@ -41,53 +89,35 @@ impl ToReport for DiagnosticError {
     }
 }
 
-/// Modo REPL interativo; ainda não implementado.
-fn run_prompt() -> Result<(), Box<dyn ToReport>> {
-    todo!()
-}
-
-/// Executa o scanner e parser sobre o `SourceFile`, imprime tokens e AST.
-fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
+fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
+    // ── Stage 1: Lex ─────────────────────────────────────────────────────────
     let mut scanner = Scanner::new(source);
     scanner.scan();
 
-    let token_count = scanner.tokens.len();
-    println!("=== Tokens ({token_count}) ===");
-    for token in &scanner.tokens {
-        let lexeme = &scanner.src.source.as_str()[token.span.start..token.span.end];
-        let kind_str = format!("{:?}", token.kind);
-        println!(
-            "  [{:3}:{:<3}]  {:<35} {:?}",
-            token.line, token.col, kind_str, lexeme
-        );
+    if args.dump_tokens {
+        dump_tokens(&scanner);
     }
 
-    let diag_count = scanner.diagnostics.len();
-    if diag_count > 0 {
-        eprintln!("\n=== Diagnostics ({diag_count}) ===");
-        for diagnostic in &scanner.diagnostics {
-            print_report(&diagnostic.to_report());
+    let lex_errors = scanner.diagnostics.len();
+    if lex_errors > 0 {
+        eprintln!("\n=== Lex Errors ({lex_errors}) ===");
+        for d in &scanner.diagnostics {
+            print_report(&d.to_report());
         }
-    } else {
-        println!("\n=== Diagnostics (0) ===");
+        return Err(Box::new(DiagnosticError { count: lex_errors }));
     }
 
-    if diag_count > 0 {
-        return Err(Box::new(DiagnosticError { count: diag_count }));
+    if args.only_lex {
+        return Ok(());
     }
 
+    // ── Stage 2: Parse ───────────────────────────────────────────────────────
     let mut parser = Parser::new(scanner.tokens);
     let program = match parser.parse_program() {
-        Ok(p) => {
-            println!("\n=== AST ({}) ===", p.decls.len());
-            for decl in &p.decls {
-                println!("{:#?}", decl);
-            }
-            p
-        }
+        Ok(p) => p,
         Err(errors) => {
             let count = errors.len();
-            eprintln!("\n=== Syntax Errors ({count}) ===");
+            eprintln!("\n=== Parse Errors ({count}) ===");
             for e in &errors {
                 print_report(&e.to_report());
             }
@@ -95,18 +125,59 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
         }
     };
 
-    let semantic_errors = analyse(&program);
-    let sem_count = semantic_errors.len();
+    if args.dump_ast {
+        dump_ast(&program);
+    }
+
+    if args.only_parse {
+        return Ok(());
+    }
+
+    // ── Stage 3: Semantic ────────────────────────────────────────────────────
+    let sem_errors = analyse(&program);
+    let sem_count = sem_errors.len();
     if sem_count > 0 {
         eprintln!("\n=== Semantic Errors ({sem_count}) ===");
-        for e in &semantic_errors {
+        for e in &sem_errors {
             print_report(&e.to_report());
         }
         return Err(Box::new(DiagnosticError { count: sem_count }));
     }
 
+    if args.only_semantic {
+        return Ok(());
+    }
+
+    // ── Stage 4: IR / Codegen ────────────────────────────────────────────────
+    if args.dump_ir {
+        eprintln!("=== IR (not yet implemented) ===");
+    }
+
     Ok(())
 }
+
+// ── Dump helpers ─────────────────────────────────────────────────────────────
+
+fn dump_tokens(scanner: &Scanner) {
+    println!("=== Tokens ({}) ===", scanner.tokens.len());
+    for token in &scanner.tokens {
+        let lexeme = &scanner.src.source.as_str()[token.span.start..token.span.end];
+        let len = token.span.end - token.span.start;
+        let col_end = token.col + len.saturating_sub(1);
+        let kind_str = format!("{:?}", token.kind);
+        println!(
+            "[{:3}:{:<3}-{:3}:{:<3}]  {:<35} {:?}",
+            token.line, token.col, token.line, col_end, kind_str, lexeme
+        );
+    }
+}
+
+fn dump_ast(program: &crusty::common::ast::ast::Program) {
+    println!("=== AST ===");
+    print!("{}", pretty_program(program));
+}
+
+// ── Error reporting ───────────────────────────────────────────────────────────
 
 fn print_report(report: &Report) {
     eprintln!("  error: {}", report.message);
@@ -121,27 +192,14 @@ fn print_report(report: &Report) {
     }
 }
 
-/// Lê o arquivo no caminho informado e delega a execução para `run`.
-fn run_file(path: &str) -> Result<(), Box<dyn ToReport>> {
-    let source = SourceFile::from_path(PathBuf::from(path))?;
-    run(source)?;
-    Ok(())
-}
-
-/// Imprime o `Report` de erro no stderr de forma estruturada e encerra o processo com código 74.
-fn report_and_exit(e: Box<dyn ToReport>) {
+fn report_and_exit(e: Box<dyn ToReport>) -> ! {
     let report = e.to_report();
-
-    eprintln!("--- ERROR ---");
-    eprintln!("Message: {}", report.message);
-
+    eprintln!("error: {}", report.message);
     if let Some(sys) = report.system {
-        eprintln!("System Info: {}", sys);
+        eprintln!("system: {}", sys);
     }
-
     if let Some(help) = report.help {
-        eprintln!("Help: {}", help);
+        eprintln!("help: {}", help);
     }
-
-    std::process::exit(74);
+    exit(74);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,17 @@ impl CliArgs {
                 "--only-lex" => cli.only_lex = true,
                 "--only-parse" => cli.only_parse = true,
                 "--only-semantic" => cli.only_semantic = true,
+                _ if arg.starts_with("--") => {
+                    eprintln!("error: unknown flag '{arg}'");
+                    exit(64);
+                }
+                _ if cli.input_file.is_some() => {
+                    eprintln!(
+                        "error: multiple input files provided ('{}' and '{arg}')",
+                        cli.input_file.unwrap()
+                    );
+                    exit(64);
+                }
                 _ => cli.input_file = Some(arg.clone()),
             }
         }
@@ -105,6 +116,10 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
             print_report(&d.to_report());
         }
         return Err(Box::new(DiagnosticError { count: lex_errors }));
+    }
+
+    if args.dump_ir {
+        eprintln!("=== IR (not yet implemented) ===");
     }
 
     if args.only_lex {
@@ -146,11 +161,6 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
 
     if args.only_semantic {
         return Ok(());
-    }
-
-    // ── Stage 4: IR / Codegen ────────────────────────────────────────────────
-    if args.dump_ir {
-        eprintln!("=== IR (not yet implemented) ===");
     }
 
     Ok(())


### PR DESCRIPTION
## Contexto

Resolve #131

Antes desta PR o compilador executava o pipeline completo sem dar visibilidade das estruturas intermediárias. Qualquer bug no lexer, parser ou analisador semântico exigia inserção de `println!` manual e recompilação.

---

## Mudanças

### `src/main.rs` — refatoração do ponto de entrada

Substituído o parser de args ad-hoc por `CliArgs`, uma struct de parsing manual (sem dependências externas) que lê todos os flags antes de iniciar qualquer estágio.

**Flags implementadas:**

| Flag | Comportamento |
|---|---|
| `--dump-tokens` | Imprime todos os tokens após o lex, com span `[linha:col_start-col_end]`, kind e lexema |
| `--dump-ast` | Imprime a AST em formato de árvore após o parse |
| `--dump-ir` | Stub: informa que codegen ainda não está implementado |
| `--only-lex` | Encerra após lexer (não executa parser) |
| `--only-parse` | Encerra após parser (não executa semântica) |
| `--only-semantic` | Encerra após análise semântica (não executa codegen) |

**Regras de comportamento:**
- Flags `--dump-*` e `--only-*` são **combináveis**: `--dump-tokens --only-lex` exibe tokens e encerra antes do parser.
- Se um estágio produz erros, o pipeline **interrompe imediatamente** — erros são reportados antes de qualquer dump do estágio seguinte.
- O help é exibido automaticamente quando nenhum arquivo é fornecido.

**Exemplo de saída `--dump-tokens`:**
```
=== Tokens (15) ===
[  3:1  -  3:3  ]  Int                                 "int"
[  3:5  -  3:8  ]  Identifier("main")                  "main"
[  3:9  -  3:9  ]  LeftParen                           "("
...
```

**Exemplo de saída `--dump-ast`:**
```
=== AST ===
Program
└── FunctionDecl(int main, params=[])
    ├── ExprStmt
    │   └── Call
    │       ├── Ident(printf)
    │       └── Literal(String("Hello, World!\n"))
    └── Return
        └── Literal(Int(0))
```

---

### `src/common/ast/pretty.rs` — novo módulo de pretty-print

Walker recursivo da AST que produz a representação em árvore com conectores `├──` / `└──` / `│` corretos para qualquer nível de profundidade.

Cobre todos os nós da gramática atual:
- **Decls:** `FunctionDecl`, `GlobalVar`, `StructDecl`, `EnumDecl`, `Typedef`
- **Stmts:** `Block`, `If`, `While`, `DoWhile`, `For`, `Switch`, `Return`, `VarDecl`, `ExprStmt`, `Break`, `Continue`
- **Exprs:** todos os operadores binários/unários, `Call`, `Cast`, `Index`, `Assign`, `CompoundAssign`, `Sizeof`, `Ternary`, `Member`

---

## Critérios de aceite

- [x] `crusty --dump-tokens arquivo.c` lista todos os tokens
- [x] `crusty --dump-ast arquivo.c` imprime a AST formatada em árvore
- [x] `crusty --only-lex arquivo.c` não executa o parser
- [x] `crusty --only-parse arquivo.c` não executa a semântica
- [x] `crusty --only-semantic arquivo.c` não executa codegen
- [x] Flags combináveis: `--dump-tokens --only-lex` funciona corretamente
- [x] Erros são reportados antes do dump do estágio seguinte
- [x] `--dump-ir` indica que codegen ainda não está implementado
- [x] `cargo test` — 179 passed, 0 failed (sem regressões)
- [x] `cargo clippy -- -D warnings` — limpo
- [x] `cargo fmt --check` — ok