### PR TITLE
feat: adiciona sistema de warnings (unused-variable, uninitialized)

### DIFF
--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -3,7 +3,11 @@ use crate::common::ast::ast::{Program, QualifierType, Type};
 use crate::common::ast::decl::Decl;
 use crate::common::ast::expr::{Expr, Literal, MemberAccess};
 use crate::common::ast::stmt::Stmt;
-use crate::common::errors::types::{CompilerError, SemanticError, SemanticErrorKind};
+use crate::common::errors::error_data::Span;
+use crate::common::errors::types::{
+    CompilerError, CompilerWarning, Diagnostic, SemanticError, SemanticErrorKind, SemanticWarning,
+    SemanticWarningKind,
+};
 
 #[derive(Default, Debug)]
 pub struct SemanticAnalyser {
@@ -11,6 +15,7 @@ pub struct SemanticAnalyser {
     /// Tipo de retorno da função sendo analisada no momento; `None` fora de funções.
     pub current_fn_ret: Option<QualifierType>,
     pub diagnostics: Vec<CompilerError>,
+    pub warnings: Vec<CompilerWarning>,
 }
 
 impl SemanticAnalyser {
@@ -19,6 +24,7 @@ impl SemanticAnalyser {
             sym: SymbolTable::new(),
             current_fn_ret: None,
             diagnostics: Vec::new(),
+            warnings: Vec::new(),
         }
     }
 
@@ -41,7 +47,7 @@ impl SemanticAnalyser {
                     kind: SemanticErrorKind::PrototypeMissingBody(name),
                 }));
         }
-        self.sym.exit_scope();
+        self.exit_scope_checking_unused();
     }
 
     pub fn analyse_decl(&mut self, decl: &Decl) {
@@ -68,6 +74,10 @@ impl SemanticAnalyser {
                     params: None,
                     decl_span: span.clone(),
                     prototype_only: false,
+                    // Globais não são rastreadas para unused/uninit: podem ser
+                    // referenciadas em outra unidade de tradução e são zero-inicializadas.
+                    used: true,
+                    initialized: true,
                 };
                 if let Err(e) = self.sym.declare(symbol) {
                     self.diagnostics.push(e);
@@ -96,6 +106,8 @@ impl SemanticAnalyser {
                             .map(|expr| expr.span())
                             .unwrap_or_else(|| enum_span.clone()),
                         prototype_only: false,
+                        used: true,
+                        initialized: true,
                     };
 
                     if let Err(e) = self.sym.declare(symbol) {
@@ -133,6 +145,8 @@ impl SemanticAnalyser {
                     params: Some(param_tys.clone()),
                     decl_span: span.clone(),
                     prototype_only: false,
+                    used: true,
+                    initialized: true,
                 };
 
                 // Se já existe um protótipo, verifica compatibilidade; senão declara.
@@ -165,6 +179,10 @@ impl SemanticAnalyser {
                         params: None,
                         decl_span: span.clone(),
                         prototype_only: false,
+                        // Parâmetros são inicializados pelo chamador e, por padrão,
+                        // não geram aviso de unused (espelha o comportamento do GCC).
+                        used: true,
+                        initialized: true,
                     };
                     if let Err(e) = self.sym.declare(symbol) {
                         self.diagnostics.push(e);
@@ -176,7 +194,7 @@ impl SemanticAnalyser {
                 }
 
                 self.current_fn_ret = prev_ret;
-                self.sym.exit_scope();
+                self.exit_scope_checking_unused();
             }
             Decl::Prototype(return_type, name, params, span) => {
                 let resolved_ret = self.resolve_type(return_type);
@@ -192,6 +210,8 @@ impl SemanticAnalyser {
                     params: Some(param_tys),
                     decl_span: span.clone(),
                     prototype_only: true,
+                    used: true,
+                    initialized: true,
                 };
 
                 // Um protótipo duplicado sobre outro protótipo idêntico é ignorado (C permite).
@@ -235,6 +255,9 @@ impl SemanticAnalyser {
                     params: None,
                     decl_span: span.clone(),
                     prototype_only: false,
+                    // Locais começam "não usadas"; a leitura marca `used = true`.
+                    used: false,
+                    initialized: init.is_some(),
                 };
                 if let Err(e) = self.sym.declare(symbol) {
                     self.diagnostics.push(e);
@@ -245,7 +268,7 @@ impl SemanticAnalyser {
                 for s in stmts {
                     self.analyse_stmt(s);
                 }
-                self.sym.exit_scope();
+                self.exit_scope_checking_unused();
             }
             Stmt::ExprStmt(expr, _) => {
                 self.analyse_expr(expr);
@@ -315,7 +338,7 @@ impl SemanticAnalyser {
                     self.analyse_expr(e);
                 }
                 self.analyse_stmt(body);
-                self.sym.exit_scope();
+                self.exit_scope_checking_unused();
             }
             Stmt::Switch(expr, cases, _) => {
                 self.analyse_expr(expr);
@@ -334,30 +357,43 @@ impl SemanticAnalyser {
     pub fn analyse_expr(&mut self, expr: &Expr) -> QualifierType {
         match expr {
             Expr::Literal(lit, _) => infer_literal_type(lit),
-            Expr::Ident(name, span) => match self.sym.lookup(name) {
-                Some(sym) => sym.ty.clone(),
-                None => {
-                    self.diagnostics
-                        .push(CompilerError::Semantic(SemanticError {
-                            span: span.clone(),
-                            kind: SemanticErrorKind::UndefinedVariable(name.clone()),
-                        }));
-                    unknown_type()
-                }
-            },
-            Expr::Assign(lhs, rhs, span) => {
-                if let Expr::Ident(name, _) = lhs.as_ref() {
-                    if let Some(sym) = self.sym.lookup(name) {
-                        if !sym.mutable {
-                            self.diagnostics
-                                .push(CompilerError::Semantic(SemanticError {
-                                    span: span.clone(),
-                                    kind: SemanticErrorKind::AssignToConst(name.clone()),
-                                }));
+            Expr::Ident(name, span) => {
+                let mut maybe_uninit = false;
+                let ty = match self.sym.lookup_mut(name) {
+                    Some(sym) => {
+                        sym.used = true;
+                        if !sym.initialized {
+                            // Marca como inicializado para não repetir o aviso nos usos seguintes.
+                            sym.initialized = true;
+                            maybe_uninit = true;
                         }
+                        sym.ty.clone()
                     }
+                    None => {
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: span.clone(),
+                                kind: SemanticErrorKind::UndefinedVariable(name.clone()),
+                            }));
+                        unknown_type()
+                    }
+                };
+                if maybe_uninit {
+                    self.warnings
+                        .push(CompilerWarning::Semantic(SemanticWarning {
+                            span: span.clone(),
+                            kind: SemanticWarningKind::MayBeUninitialized(name.clone()),
+                        }));
                 }
-                let lhs_ty = self.analyse_expr(lhs);
+                ty
+            }
+            Expr::Assign(lhs, rhs, span) => {
+                // O LHS de uma atribuição é uma escrita: marca usado + inicializado,
+                // sem disparar o aviso de "uso sem inicialização".
+                let lhs_ty = match lhs.as_ref() {
+                    Expr::Ident(name, _) => self.assign_target_type(name, span),
+                    _ => self.analyse_expr(lhs),
+                };
                 let rhs_ty = self.analyse_expr(rhs);
                 if !types_compatible_for_assign(&lhs_ty.ty, &rhs_ty.ty) {
                     self.diagnostics
@@ -622,13 +658,66 @@ impl SemanticAnalyser {
             other => other.clone(),
         }
     }
+
+    /// Resolve o tipo do alvo de uma atribuição (`x = ...`).
+    /// Marca o símbolo como usado e inicializado (é uma escrita), verifica
+    /// mutabilidade e emite os erros apropriados — sem disparar o aviso de
+    /// "uso sem inicialização", já que atribuir inicializa a variável.
+    fn assign_target_type(&mut self, name: &str, span: &Span) -> QualifierType {
+        let (ty, undefined, not_mutable) = match self.sym.lookup_mut(name) {
+            Some(sym) => {
+                sym.used = true;
+                sym.initialized = true;
+                let not_mutable = !sym.mutable;
+                (sym.ty.clone(), false, not_mutable)
+            }
+            None => (unknown_type(), true, false),
+        };
+
+        if undefined {
+            self.diagnostics
+                .push(CompilerError::Semantic(SemanticError {
+                    span: span.clone(),
+                    kind: SemanticErrorKind::UndefinedVariable(name.to_string()),
+                }));
+        } else if not_mutable {
+            self.diagnostics
+                .push(CompilerError::Semantic(SemanticError {
+                    span: span.clone(),
+                    kind: SemanticErrorKind::AssignToConst(name.to_string()),
+                }));
+        }
+        ty
+    }
+
+    /// Remove o escopo atual e emite avisos de `unused-variable` para cada
+    /// símbolo local declarado que nunca foi lido.
+    fn exit_scope_checking_unused(&mut self) {
+        if let Some(scope) = self.sym.drain_scope() {
+            for (_, sym) in scope {
+                if !sym.used {
+                    self.warnings
+                        .push(CompilerWarning::Semantic(SemanticWarning {
+                            span: sym.decl_span.clone(),
+                            kind: SemanticWarningKind::UnusedVariable(sym.name.clone()),
+                        }));
+                }
+            }
+        }
+    }
 }
 
-/// API pública: analisa o programa e retorna todos os diagnósticos semânticos.
-pub fn analyse(prog: &Program) -> Vec<CompilerError> {
+/// API pública: analisa o programa e retorna todos os diagnósticos semânticos
+/// (erros e avisos) como `Vec<Diagnostic>`.
+pub fn analyse(prog: &Program) -> Vec<Diagnostic> {
     let mut analyser = SemanticAnalyser::new();
     analyser.analyse_program(prog);
-    analyser.diagnostics
+    analyser
+        .diagnostics
+        .into_iter()
+        .map(Diagnostic::Error)
+        .chain(analyser.warnings.into_iter().map(Diagnostic::Warning))
+        .collect()
 }
 
 fn infer_literal_type(lit: &Literal) -> QualifierType {

--- a/src/analyser/symbol_table.rs
+++ b/src/analyser/symbol_table.rs
@@ -15,6 +15,12 @@ pub struct Symbol {
     pub decl_span: Span,
     /// `true` quando o símbolo veio de um protótipo sem implementação correspondente ainda.
     pub prototype_only: bool,
+    /// `false` enquanto a variável nunca foi referenciada em uma leitura.
+    /// Usado para emitir o aviso `unused-variable` ao sair do escopo.
+    pub used: bool,
+    /// `false` enquanto a variável não recebeu inicializador nem atribuição.
+    /// Usado para emitir o aviso `may-be-uninitialized` no primeiro uso em leitura.
+    pub initialized: bool,
 }
 
 #[derive(Debug, Default)]
@@ -36,6 +42,12 @@ impl SymbolTable {
 
     pub fn exit_scope(&mut self) {
         self.scopes.pop();
+    }
+
+    /// Remove o escopo atual e devolve seus símbolos, permitindo inspecioná-los
+    /// (por exemplo, para emitir avisos de `unused-variable` ao fim do escopo).
+    pub fn drain_scope(&mut self) -> Option<HashMap<String, Symbol>> {
+        self.scopes.pop()
     }
 
     /// Declara um símbolo no escopo atual. Erro se já declarado no mesmo escopo.
@@ -69,9 +81,12 @@ impl SymbolTable {
                 Ok(())
             }
             Some(existing) if existing.prototype_only => {
-                // Assinaturas compatíveis: completa o protótipo
                 if existing.ty == symbol.ty && existing.params == symbol.params {
-                    existing.prototype_only = false;
+                    if !symbol.prototype_only {
+                        // Definição completa compatível: remove o flag de protótipo pendente.
+                        existing.prototype_only = false;
+                    }
+                    // Protótipo idêntico redeclarado: ignorado silenciosamente (C permite).
                     Ok(())
                 } else {
                     Err(CompilerError::Semantic(SemanticError {
@@ -102,6 +117,12 @@ impl SymbolTable {
     /// Busca o escopo do mais interno para o mais externo
     pub fn lookup(&self, name: &str) -> Option<&Symbol> {
         self.scopes.iter().rev().find_map(|s| s.get(name))
+    }
+
+    /// Busca mutável, do escopo mais interno para o mais externo.
+    /// Permite marcar `used`/`initialized` no símbolo que efetivamente resolve o nome.
+    pub fn lookup_mut(&mut self, name: &str) -> Option<&mut Symbol> {
+        self.scopes.iter_mut().rev().find_map(|s| s.get_mut(name))
     }
 
     /// Busca apenas o escopo atual

--- a/src/common/errors/render.rs
+++ b/src/common/errors/render.rs
@@ -1,8 +1,8 @@
 // Rendering simple colors for display in error handlings
 
+use crate::common::errors::error_data::Source;
 use crate::common::errors::report::Report;
 use crate::common::errors::types::Severity;
-use crate::common::errors::{error_data::Source};
 
 /// Envolve a string `s` na sequência ANSI de cor vermelha para exibição no terminal.
 pub fn red(s: &str) -> String {

--- a/src/common/errors/render.rs
+++ b/src/common/errors/render.rs
@@ -1,25 +1,37 @@
 // Rendering simple colors for display in error handlings
 
-use crate::common::errors::{error_data::Source, report::Report};
+use crate::common::errors::report::Report;
+use crate::common::errors::types::Severity;
+use crate::common::errors::{error_data::Source};
 
 /// Envolve a string `s` na sequência ANSI de cor vermelha para exibição no terminal.
-fn red(s: &str) -> String {
+pub fn red(s: &str) -> String {
     format!("\x1b[31m{}\x1b[0m", s)
 }
 
+/// Envolve a string `s` na sequência ANSI de cor amarela (usada para warnings).
+pub fn yellow(s: &str) -> String {
+    format!("\x1b[33m{}\x1b[0m", s)
+}
+
 /// Envolve a string `s` na sequência ANSI de cor verde para exibição no terminal.
-fn green(s: &str) -> String {
+pub fn green(s: &str) -> String {
     format!("\x1b[32m{}\x1b[0m", s)
 }
 
 /// Envolve a string `s` na sequência ANSI de negrito para exibição no terminal.
-fn bold(s: &str) -> String {
+pub fn bold(s: &str) -> String {
     format!("\x1b[1m{}\x1b[0m", s)
 }
 
-/// Imprime o `Report` formatado no terminal com localização, setas indicadoras e sugestão de ajuda.
-pub fn render(report: &Report, source: &Source) {
-    println!("{}: {}", red(&bold("error")), report.message);
+/// Imprime o `Report` formatado no terminal com localização, setas indicadoras e
+/// sugestão de ajuda. A cor do rótulo (`error`/`warning`) segue a `severity`.
+pub fn render(report: &Report, source: &Source, severity: Severity) {
+    let (label, accent): (String, fn(&str) -> String) = match severity {
+        Severity::Error => (red(&bold("error")), red),
+        Severity::Warning => (yellow(&bold("warning")), yellow),
+    };
+    println!("{}: {}", label, report.message);
 
     if let Some(span) = &report.span {
         if span.end_line == span.line {
@@ -39,7 +51,7 @@ pub fn render(report: &Report, source: &Source) {
                 indicator.push('^');
             }
 
-            println!("  | {}", red(&indicator));
+            println!("  | {}", accent(&indicator));
         }
     }
 

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -25,6 +25,66 @@ impl ToReport for CompilerError {
     }
 }
 
+/// Nível de severidade de um diagnóstico.
+/// `Error` impede a compilação; `Warning` apenas sinaliza um problema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+/// Diagnóstico unificado: pode ser um erro (impede a compilação) ou um aviso.
+/// O analisador semântico produz `Vec<Diagnostic>` misturando ambos.
+#[derive(Debug)]
+pub enum Diagnostic {
+    Error(CompilerError),
+    Warning(CompilerWarning),
+}
+
+impl Diagnostic {
+    /// Retorna a severidade deste diagnóstico.
+    pub fn severity(&self) -> Severity {
+        match self {
+            Diagnostic::Error(_) => Severity::Error,
+            Diagnostic::Warning(_) => Severity::Warning,
+        }
+    }
+
+    /// Retorna `true` quando este diagnóstico impede a compilação.
+    pub fn is_error(&self) -> bool {
+        matches!(self, Diagnostic::Error(_))
+    }
+
+    /// Retorna `true` quando este diagnóstico é apenas um aviso.
+    pub fn is_warning(&self) -> bool {
+        matches!(self, Diagnostic::Warning(_))
+    }
+}
+
+impl ToReport for Diagnostic {
+    /// Delega a conversão para o `Report` do erro ou aviso subjacente.
+    fn to_report(&self) -> Report {
+        match self {
+            Diagnostic::Error(e) => e.to_report(),
+            Diagnostic::Warning(w) => w.to_report(),
+        }
+    }
+}
+
+/// Categoria de aviso do compilador. Apenas semânticos por enquanto.
+#[derive(Debug)]
+pub enum CompilerWarning {
+    Semantic(SemanticWarning),
+}
+
+impl ToReport for CompilerWarning {
+    fn to_report(&self) -> Report {
+        match self {
+            CompilerWarning::Semantic(w) => w.to_report(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum LexicalErrorKind {
     /// Caractere que o lexer não reconhece (ex: `@`, `$`)
@@ -249,6 +309,52 @@ impl ToReport for SemanticError {
                     self.span.clone(),
                     format!("'{}' não é indexável (esperado array ou ponteiro)", found),
                 ),
+        }
+    }
+}
+
+/*
+ * Avisos semânticos são problemas que não impedem a compilação, mas devem ser
+ * sinalizados ao usuário. Exemplos:
+ *      - variável declarada mas nunca lida (unused-variable)
+ *      - variável possivelmente usada sem inicialização (uninitialized)
+ */
+
+#[derive(Debug)]
+pub enum SemanticWarningKind {
+    /// Variável declarada mas nunca lida em nenhum ponto do escopo.
+    UnusedVariable(String),
+    /// Variável lida antes de receber qualquer inicializador ou atribuição.
+    MayBeUninitialized(String),
+}
+
+#[derive(Debug)]
+pub struct SemanticWarning {
+    pub span: Span,
+    pub kind: SemanticWarningKind,
+}
+
+impl ToReport for SemanticWarning {
+    /// Converte o aviso semântico em `Report` com mensagem, span e sugestão específicos.
+    fn to_report(&self) -> Report {
+        match &self.kind {
+            SemanticWarningKind::UnusedVariable(var) => Report::new("unused variable")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    format!("variavel '{}' declarada mas nunca lida", var),
+                )
+                .with_help("remova a declaracao ou use a variavel"),
+
+            SemanticWarningKind::MayBeUninitialized(var) => {
+                Report::new("may be used uninitialized")
+                    .with_span(self.span.clone())
+                    .with_label(
+                        self.span.clone(),
+                        format!("variavel '{}' pode ser usada sem inicializacao", var),
+                    )
+                    .with_help("inicialize a variavel antes de usa-la")
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,8 +126,7 @@ fn run(source: SourceFile, config: &DiagnosticsConfig) -> Result<(), Box<dyn ToR
     };
 
     let diagnostics = analyse(&program);
-    let (errors, warnings): (Vec<_>, Vec<_>) =
-        diagnostics.iter().partition(|d| d.is_error());
+    let (errors, warnings): (Vec<_>, Vec<_>) = diagnostics.iter().partition(|d| d.is_error());
 
     let warn_count = warnings.len();
     if warn_count > 0 && !config.no_warnings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use crusty::analyser::analyse;
+use crusty::common::errors::render::{bold, red, yellow};
 use crusty::common::errors::report::{Report, ToReport};
+use crusty::common::errors::types::Severity;
 use crusty::common::input::source::SourceFile;
 use crusty::lexer::scanner::Scanner;
 use crusty::parser::Parser;
@@ -7,23 +9,51 @@ use std::env;
 use std::path::PathBuf;
 use std::process::exit;
 
-/// Ponto de entrada: decide entre modo interativo (sem args) ou compilação de arquivo (1 arg).
+/// Opções de diagnóstico passadas via linha de comando.
+#[derive(Default, Clone, Copy)]
+struct DiagnosticsConfig {
+    /// `--Werror`: trata todos os warnings como erros (faz a compilação falhar).
+    werror: bool,
+    /// `--no-warnings`: suprime a exibição de warnings.
+    no_warnings: bool,
+}
+
+/// Ponto de entrada: faz o parse das flags, decide entre modo interativo
+/// (sem arquivo) ou compilação de arquivo.
 fn main() -> std::io::Result<()> {
     let args: Vec<_> = env::args().collect();
-    match args.len() {
-        1 => {
+    let mut config = DiagnosticsConfig::default();
+    let mut file: Option<String> = None;
+
+    for arg in args.iter().skip(1) {
+        match arg.as_str() {
+            "--Werror" => config.werror = true,
+            "--no-warnings" => config.no_warnings = true,
+            s if s.starts_with("--") => {
+                eprintln!("unknown flag: {}", s);
+                eprintln!("Usage: crusty [--Werror] [--no-warnings] [script]");
+                exit(64);
+            }
+            s => {
+                if file.is_some() {
+                    eprintln!("Usage: crusty [--Werror] [--no-warnings] [script]");
+                    exit(64);
+                }
+                file = Some(s.to_string());
+            }
+        }
+    }
+
+    match file {
+        None => {
             if let Err(e) = run_prompt() {
                 report_and_exit(e);
             }
         }
-        2 => {
-            if let Err(e) = run_file(&args[1]) {
+        Some(path) => {
+            if let Err(e) = run_file(&path, &config) {
                 report_and_exit(e);
             }
-        }
-        _ => {
-            eprintln!("Usage: crusty [script]");
-            exit(64);
         }
     }
     Ok(())
@@ -47,7 +77,7 @@ fn run_prompt() -> Result<(), Box<dyn ToReport>> {
 }
 
 /// Executa o scanner e parser sobre o `SourceFile`, imprime tokens e AST.
-fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
+fn run(source: SourceFile, config: &DiagnosticsConfig) -> Result<(), Box<dyn ToReport>> {
     let mut scanner = Scanner::new(source);
     scanner.scan();
 
@@ -66,7 +96,7 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
     if diag_count > 0 {
         eprintln!("\n=== Diagnostics ({diag_count}) ===");
         for diagnostic in &scanner.diagnostics {
-            print_report(&diagnostic.to_report());
+            print_report(&diagnostic.to_report(), Severity::Error);
         }
     } else {
         println!("\n=== Diagnostics (0) ===");
@@ -89,27 +119,47 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
             let count = errors.len();
             eprintln!("\n=== Syntax Errors ({count}) ===");
             for e in &errors {
-                print_report(&e.to_report());
+                print_report(&e.to_report(), Severity::Error);
             }
             return Err(Box::new(DiagnosticError { count }));
         }
     };
 
-    let semantic_errors = analyse(&program);
-    let sem_count = semantic_errors.len();
-    if sem_count > 0 {
-        eprintln!("\n=== Semantic Errors ({sem_count}) ===");
-        for e in &semantic_errors {
-            print_report(&e.to_report());
+    let diagnostics = analyse(&program);
+    let (errors, warnings): (Vec<_>, Vec<_>) =
+        diagnostics.iter().partition(|d| d.is_error());
+
+    let warn_count = warnings.len();
+    if warn_count > 0 && !config.no_warnings {
+        eprintln!("\n=== Warnings ({warn_count}) ===");
+        for w in &warnings {
+            print_report(&w.to_report(), Severity::Warning);
         }
-        return Err(Box::new(DiagnosticError { count: sem_count }));
+    }
+
+    if !errors.is_empty() {
+        let count = errors.len();
+        eprintln!("\n=== Semantic Errors ({count}) ===");
+        for e in &errors {
+            print_report(&e.to_report(), Severity::Error);
+        }
+        return Err(Box::new(DiagnosticError { count }));
+    }
+
+    // `--Werror`: warnings são tratados como erros e falham a compilação.
+    if config.werror && warn_count > 0 {
+        return Err(Box::new(DiagnosticError { count: warn_count }));
     }
 
     Ok(())
 }
 
-fn print_report(report: &Report) {
-    eprintln!("  error: {}", report.message);
+fn print_report(report: &Report, severity: Severity) {
+    let label = match severity {
+        Severity::Error => red(&bold("error")),
+        Severity::Warning => yellow(&bold("warning")),
+    };
+    eprintln!("  {}: {}", label, report.message);
     if let Some(span) = &report.span {
         eprintln!("    --> {}:{}", span.line, span.column_start);
     }
@@ -122,9 +172,9 @@ fn print_report(report: &Report) {
 }
 
 /// Lê o arquivo no caminho informado e delega a execução para `run`.
-fn run_file(path: &str) -> Result<(), Box<dyn ToReport>> {
+fn run_file(path: &str, config: &DiagnosticsConfig) -> Result<(), Box<dyn ToReport>> {
     let source = SourceFile::from_path(PathBuf::from(path))?;
-    run(source)?;
+    run(source, config)?;
     Ok(())
 }
 

--- a/src/tests/analyzer_test.rs
+++ b/src/tests/analyzer_test.rs
@@ -51,6 +51,8 @@ mod test {
                 params: None,
                 decl_span: dummy_span(),
                 prototype_only: false,
+                used: false,
+                initialized: true,
             })
             .unwrap();
 
@@ -86,6 +88,8 @@ mod test {
                 params: None,
                 decl_span: dummy_span(),
                 prototype_only: false,
+                used: false,
+                initialized: true,
             })
             .unwrap();
 
@@ -120,6 +124,8 @@ mod test {
                 params: None,
                 decl_span: dummy_span(),
                 prototype_only: false,
+                used: false,
+                initialized: true,
             })
             .unwrap();
 

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -6,7 +6,9 @@ mod tests {
     use crate::common::ast::expr::{Expr, Literal, MemberAccess};
     use crate::common::ast::stmt::Stmt;
     use crate::common::errors::error_data::Span;
-    use crate::common::errors::types::SemanticErrorKind;
+    use crate::common::errors::types::{
+        CompilerError, Diagnostic, SemanticErrorKind, SemanticWarningKind,
+    };
 
     fn span() -> Span {
         Span {
@@ -44,7 +46,7 @@ mod tests {
     fn program(stmts: Vec<Stmt>) -> Program {
         Program {
             decls: vec![Decl::Function(
-                qty(Type::Void),
+                qty(Type::Int),
                 "main".into(),
                 vec![],
                 stmts,
@@ -53,8 +55,19 @@ mod tests {
         }
     }
 
-    fn analyse(prog: &Program) -> Vec<crate::common::errors::types::CompilerError> {
+    fn analyse(prog: &Program) -> Vec<Diagnostic> {
         crate::analyser::analyse(prog)
+    }
+
+    /// Extrai apenas os erros (ignora avisos) de um conjunto de diagnósticos.
+    fn errors(diags: &[Diagnostic]) -> Vec<&CompilerError> {
+        diags
+            .iter()
+            .filter_map(|d| match d {
+                Diagnostic::Error(e) => Some(e),
+                _ => None,
+            })
+            .collect()
     }
 
     // ── VarDecl ───────────────────────────────────────────────────────────────
@@ -71,11 +84,11 @@ mod tests {
     #[test]
     fn undeclared_variable_emits_error() {
         let prog = program(vec![Stmt::ExprStmt(ident("x"), span())]);
-        let errors = analyse(&prog);
-        assert_eq!(errors.len(), 1);
+        let diags = analyse(&prog);
+        assert_eq!(diags.len(), 1);
         assert!(matches!(
-            &errors[0],
-            crate::common::errors::types::CompilerError::Semantic(e)
+            &diags[0],
+            Diagnostic::Error(CompilerError::Semantic(e))
                 if matches!(e.kind, SemanticErrorKind::UndefinedVariable(_))
         ));
     }
@@ -86,10 +99,11 @@ mod tests {
             Stmt::VarDecl(qty(Type::Int), "x".into(), None, span()),
             Stmt::VarDecl(qty(Type::Int), "x".into(), None, span()),
         ]);
-        let errors = analyse(&prog);
-        assert!(errors.iter().any(|e| matches!(
+        let diags = analyse(&prog);
+        let errs = errors(&diags);
+        assert!(errs.iter().any(|e| matches!(
             e,
-            crate::common::errors::types::CompilerError::Semantic(se)
+            CompilerError::Semantic(se)
                 if matches!(se.kind, SemanticErrorKind::Redeclaration(_))
         )));
     }
@@ -103,7 +117,8 @@ mod tests {
                 span(),
             ),
         ]);
-        assert!(analyse(&prog).is_empty());
+        // sem erros (apenas warnings de unused-variable, que são esperados)
+        assert!(errors(&analyse(&prog)).is_empty());
     }
 
     // ── AssignToConst ─────────────────────────────────────────────────────────
@@ -117,10 +132,11 @@ mod tests {
                 span(),
             ),
         ]);
-        let errors = analyse(&prog);
-        assert!(errors.iter().any(|e| matches!(
+        let diags = analyse(&prog);
+        let errs = errors(&diags);
+        assert!(errs.iter().any(|e| matches!(
             e,
-            crate::common::errors::types::CompilerError::Semantic(se)
+            CompilerError::Semantic(se)
                 if matches!(&se.kind, SemanticErrorKind::AssignToConst(n) if n == "PI")
         )));
     }
@@ -148,10 +164,10 @@ mod tests {
             )],
         };
 
-        let errors = analyse(&prog);
-        assert!(errors.iter().any(|e| matches!(
+        let diags = analyse(&prog);
+        assert!(diags.iter().any(|e| matches!(
             e,
-            crate::common::errors::types::CompilerError::Semantic(se)
+            Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                 if matches!(&se.kind, SemanticErrorKind::TypeMismatch { .. })
         )));
     }
@@ -164,8 +180,8 @@ mod tests {
             Stmt::ExprStmt(ident("a"), span()),
             Stmt::ExprStmt(ident("b"), span()),
         ]);
-        let errors = analyse(&prog);
-        assert_eq!(errors.len(), 2);
+        let diags = analyse(&prog);
+        assert_eq!(diags.len(), 2);
     }
 
     // ── inferência de tipo básica ─────────────────────────────────────────────
@@ -202,6 +218,8 @@ mod tests {
                 params: None,
                 decl_span: span(),
                 prototype_only: false,
+                used: false,
+                initialized: true,
             })
             .unwrap();
         let ty = analyser.analyse_expr(&ident("f"));
@@ -232,7 +250,7 @@ mod tests {
         let expr = Expr::Binary(
             Box::new(int_lit(1)),
             crate::common::ast::expr::BinOp::Add,
-            Box::new(Expr::Literal(Literal::Double(3.14), span())),
+            Box::new(Expr::Literal(Literal::Double(1.5), span())),
             span(),
         );
         let ty = analyser.analyse_expr(&expr);
@@ -253,6 +271,8 @@ mod tests {
                 params: None,
                 decl_span: span(),
                 prototype_only: false,
+                used: false,
+                initialized: true,
             })
             .unwrap();
         let expr = Expr::Binary(
@@ -279,6 +299,8 @@ mod tests {
                 params: None,
                 decl_span: span(),
                 prototype_only: false,
+                used: false,
+                initialized: true,
             })
             .unwrap();
         let expr = Expr::Binary(
@@ -393,7 +415,7 @@ mod tests {
             Stmt::ExprStmt(
                 Expr::Assign(
                     Box::new(ident("x")),
-                    Box::new(Expr::Literal(Literal::Double(3.14), span())),
+                    Box::new(Expr::Literal(Literal::Double(1.5), span())),
                     span(),
                 ),
                 span(),
@@ -418,11 +440,12 @@ mod tests {
                 span(),
             ),
         ]);
-        let errors = analyse(&prog);
+        let diags = analyse(&prog);
+        let errs = errors(&diags);
         assert!(
-            errors.iter().any(|e| matches!(
+            errs.iter().any(|e| matches!(
                 e,
-                crate::common::errors::types::CompilerError::Semantic(se)
+                CompilerError::Semantic(se)
                     if matches!(&se.kind, SemanticErrorKind::TypeMismatch { .. })
             )),
             "int = string deve emitir TypeMismatch"
@@ -443,11 +466,12 @@ mod tests {
                 span(),
             ),
         ]);
-        let errors = analyse(&prog);
+        let diags = analyse(&prog);
+        let errs = errors(&diags);
         assert!(
-            errors.iter().any(|e| matches!(
+            errs.iter().any(|e| matches!(
                 e,
-                crate::common::errors::types::CompilerError::Semantic(se)
+                CompilerError::Semantic(se)
                     if matches!(&se.kind, SemanticErrorKind::TypeMismatch { .. })
             )),
             "int* = int deve emitir TypeMismatch"
@@ -492,6 +516,93 @@ mod tests {
             ],
         };
 
+        // sem erros (p é lido via member access; apenas pode haver warnings)
+        assert!(errors(&analyse(&prog)).is_empty());
+    }
+
+    // ── Warnings: unused-variable ─────────────────────────────────────────────
+
+    #[test]
+    fn unused_variable_emits_warning() {
+        // int x = 5; return 0;   -> x declarada mas nunca lida
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(5)), span()),
+            Stmt::Return(Some(int_lit(0)), span()),
+        ]);
+        let diags = analyse(&prog);
+        assert!(errors(&diags).is_empty(), "não deve haver erros");
+        assert!(
+            diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(&w.kind, SemanticWarningKind::UnusedVariable(n) if n == "x")
+            )),
+            "deve emitir warning de unused-variable para 'x'"
+        );
+    }
+
+    #[test]
+    fn used_variable_emits_no_warning() {
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(5)), span()),
+            Stmt::Return(Some(ident("x")), span()),
+        ]);
+        let diags = analyse(&prog);
+        assert!(
+            diags.is_empty(),
+            "variável usada não deve gerar nenhum diagnóstico"
+        );
+    }
+
+    #[test]
+    fn assignment_counts_as_use_no_unused_warning() {
+        // int x = 0; x = 1;  -> x é referenciada (atribuição), sem warning de unused
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(0)), span()),
+            Stmt::ExprStmt(
+                Expr::Assign(Box::new(ident("x")), Box::new(int_lit(1)), span()),
+                span(),
+            ),
+        ]);
+        let diags = analyse(&prog);
+        assert!(
+            !diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(w.kind, SemanticWarningKind::UnusedVariable(_))
+            )),
+            "atribuir à variável conta como uso"
+        );
+    }
+
+    // ── Warnings: uninitialized ───────────────────────────────────────────────
+
+    #[test]
+    fn uninitialized_use_emits_warning() {
+        // int x; return x;  -> x lida sem inicialização
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), None, span()),
+            Stmt::Return(Some(ident("x")), span()),
+        ]);
+        let diags = analyse(&prog);
+        assert!(errors(&diags).is_empty(), "não deve haver erros");
+        assert!(
+            diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(&w.kind, SemanticWarningKind::MayBeUninitialized(n) if n == "x")
+            )),
+            "deve emitir warning de uninitialized para 'x'"
+        );
+    }
+
+    #[test]
+    fn initialized_then_used_emits_no_warning() {
+        // int x = 0; return x;  -> x inicializada, nenhum warning
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(0)), span()),
+            Stmt::Return(Some(ident("x")), span()),
+        ]);
         assert!(analyse(&prog).is_empty());
     }
 
@@ -550,10 +661,10 @@ mod tests {
                 ),
             ],
         };
-        let errors = analyse(&prog);
-        assert!(errors.iter().any(|e| matches!(
+        let diags = analyse(&prog);
+        assert!(diags.iter().any(|e| matches!(
             e,
-            crate::common::errors::types::CompilerError::Semantic(se)
+            Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                 if matches!(&se.kind, crate::common::errors::types::SemanticErrorKind::ArityMismatch { .. })
         )));
     }
@@ -585,10 +696,10 @@ mod tests {
                 ),
             ],
         };
-        let errors = analyse(&prog);
-        assert!(errors.iter().any(|e| matches!(
+        let diags = analyse(&prog);
+        assert!(diags.iter().any(|e| matches!(
             e,
-            crate::common::errors::types::CompilerError::Semantic(se)
+            Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                 if matches!(&se.kind, crate::common::errors::types::SemanticErrorKind::TypeMismatch { .. })
         )));
     }
@@ -605,6 +716,8 @@ mod tests {
                 params: None,
                 decl_span: span(),
                 prototype_only: false,
+                used: true,
+                initialized: true,
             })
             .unwrap();
     }
@@ -619,6 +732,8 @@ mod tests {
                 params: None,
                 decl_span: span(),
                 prototype_only: false,
+                used: true,
+                initialized: true,
             })
             .unwrap();
     }
@@ -685,6 +800,8 @@ mod tests {
                 params: None,
                 decl_span: span(),
                 prototype_only: false,
+                used: true,
+                initialized: true,
             })
             .unwrap();
         let expr = Expr::Index(Box::new(ident("s")), Box::new(int_lit(0)), span());
@@ -713,10 +830,10 @@ mod tests {
                 span(),
             )],
         };
-        let errors = analyse(&prog);
-        assert!(errors.iter().any(|e| matches!(
+        let diags = analyse(&prog);
+        assert!(diags.iter().any(|e| matches!(
             e,
-            crate::common::errors::types::CompilerError::Semantic(se)
+            Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                 if matches!(&se.kind, crate::common::errors::types::SemanticErrorKind::CallNonFunction(_))
         )));
     }
@@ -786,11 +903,11 @@ mod tests {
                 span(),
             )],
         };
-        let errors = analyse(&prog);
+        let diags = analyse(&prog);
         assert!(
-            errors.iter().any(|e| matches!(
+            diags.iter().any(|e| matches!(
                 e,
-                crate::common::errors::types::CompilerError::Semantic(se)
+                Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                     if matches!(&se.kind, SemanticErrorKind::UndefinedVariable(n) if n == "soma")
             )),
             "chamada sem protótipo deve emitir UndefinedVariable"
@@ -819,11 +936,11 @@ mod tests {
                 ),
             ],
         };
-        let errors = analyse(&prog);
+        let diags = analyse(&prog);
         assert!(
-            errors.iter().any(|e| matches!(
+            diags.iter().any(|e| matches!(
                 e,
-                crate::common::errors::types::CompilerError::Semantic(se)
+                Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                     if matches!(&se.kind, SemanticErrorKind::PrototypeMismatch { name, .. } if name == "soma")
             )),
             "retorno diferente entre protótipo e definição deve emitir PrototypeMismatch"
@@ -852,11 +969,11 @@ mod tests {
                 ),
             ],
         };
-        let errors = analyse(&prog);
+        let diags = analyse(&prog);
         assert!(
-            errors.iter().any(|e| matches!(
+            diags.iter().any(|e| matches!(
                 e,
-                crate::common::errors::types::CompilerError::Semantic(se)
+                Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                     if matches!(&se.kind, SemanticErrorKind::PrototypeMismatch { name, .. } if name == "soma")
             )),
             "parâmetros diferentes entre protótipo e definição deve emitir PrototypeMismatch"
@@ -865,7 +982,7 @@ mod tests {
 
     /// Caso 5: protótipo sem implementação correspondente → `PrototypeMissingBody`.
     #[test]
-    fn prototype_without_body_emits_warning() {
+    fn prototype_without_body_emits_error() {
         // int soma(int a, int b);  // nunca implementada
         let prog = Program {
             decls: vec![Decl::Prototype(
@@ -875,14 +992,36 @@ mod tests {
                 span(),
             )],
         };
-        let errors = analyse(&prog);
+        let diags = analyse(&prog);
         assert!(
-            errors.iter().any(|e| matches!(
+            diags.iter().any(|e| matches!(
                 e,
-                crate::common::errors::types::CompilerError::Semantic(se)
+                Diagnostic::Error(crate::common::errors::types::CompilerError::Semantic(se))
                     if matches!(&se.kind, SemanticErrorKind::PrototypeMissingBody(n) if n == "soma")
             )),
             "protótipo sem implementação deve emitir PrototypeMissingBody"
+        );
+    }
+
+    #[test]
+    fn assignment_before_use_initializes_variable() {
+        // int x; x = 5; return x;  -> atribuição inicializa antes do uso
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), None, span()),
+            Stmt::ExprStmt(
+                Expr::Assign(Box::new(ident("x")), Box::new(int_lit(5)), span()),
+                span(),
+            ),
+            Stmt::Return(Some(ident("x")), span()),
+        ]);
+        let diags = analyse(&prog);
+        assert!(
+            !diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(w.kind, SemanticWarningKind::MayBeUninitialized(_))
+            )),
+            "atribuição antes do uso inicializa a variável"
         );
     }
 }

--- a/src/tests/symbol_test.rs
+++ b/src/tests/symbol_test.rs
@@ -29,6 +29,8 @@ mod tests {
             params: None,
             decl_span: span(),
             prototype_only: false,
+            used: false,
+            initialized: false,
         }
     }
 


### PR DESCRIPTION
## Contexto
O sistema de diagnósticos só emitia erros. Esta PR introduz a distinção
entre erros e warnings e implementa os primeiros avisos semânticos.

## Mudanças
- `Severity {Error, Warning}` + `Diagnostic` unificando erros e avisos
- `CompilerWarning`/`SemanticWarning` com `to_report`
- `Symbol` rastreia `used`/`initialized`; `lookup_mut` + `drain_scope`
- Warnings: **unused-variable** e **may-be-uninitialized**
- Render diferenciado: `warning:` (amarelo) vs `error:` (vermelho)
- Flags CLI: `--Werror` e `--no-warnings`

## Critérios de aceite
- [x] Distinção Error/Warning no sistema de diagnósticos
- [x] Render diferenciado no terminal (cores)
- [x] Pelo menos um warning implementado com testes (2 warnings, 6 testes novos)
- [x] `cargo test` passando — **155 passed; 0 failed**