### PR TITLE
Feat(opt): adicionar infraestrutura de passes de otimização

### DIFF
--- a/src/codegen/inter/mod.rs
+++ b/src/codegen/inter/mod.rs
@@ -1,1 +1,69 @@
+pub mod opt;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cfg {
+    pub blocks: Vec<BasicBlock>,
+}
+
+impl Cfg {
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+
+    pub fn add_block(&mut self, block: BasicBlock) {
+        self.blocks.push(block);
+    }
+}
+
+impl Default for Cfg {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BasicBlock {
+    pub label: String,
+    pub instructions: Vec<Instruction>,
+    pub successors: Vec<usize>,
+}
+
+impl BasicBlock {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            instructions: Vec::new(),
+            successors: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Instruction {
+    Assign {
+        dst: String,
+        value: Value,
+    },
+    Binary {
+        dst: String,
+        op: BinaryOp,
+        lhs: Value,
+        rhs: Value,
+    },
+    Nop,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Value {
+    Int(i64),
+    Temp(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+}

--- a/src/codegen/inter/opt/constant_fold.rs
+++ b/src/codegen/inter/opt/constant_fold.rs
@@ -1,0 +1,57 @@
+use super::OptPass;
+use crate::codegen::inter::{BinaryOp, Cfg, Instruction, Value};
+
+pub struct ConstantFoldPass;
+
+impl OptPass for ConstantFoldPass {
+    fn name(&self) -> &'static str {
+        "constant-fold"
+    }
+
+    fn run(&self, cfg: &mut Cfg) -> bool {
+        let mut changed = false;
+
+        for block in &mut cfg.blocks {
+            for instruction in &mut block.instructions {
+                if let Instruction::Binary { dst, op, lhs, rhs } = instruction {
+                    let folded = fold_binary(*op, lhs, rhs);
+                    if let Some(value) = folded {
+                        *instruction = Instruction::Assign {
+                            dst: dst.clone(),
+                            value,
+                        };
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        changed
+    }
+}
+
+fn fold_binary(op: BinaryOp, lhs: &Value, rhs: &Value) -> Option<Value> {
+    let (Value::Int(lhs), Value::Int(rhs)) = (lhs, rhs) else {
+        return None;
+    };
+
+    let value = match op {
+        BinaryOp::Add => lhs.checked_add(*rhs)?,
+        BinaryOp::Sub => lhs.checked_sub(*rhs)?,
+        BinaryOp::Mul => lhs.checked_mul(*rhs)?,
+        BinaryOp::Div => {
+            if *rhs == 0 {
+                return None;
+            }
+            lhs.checked_div(*rhs)?
+        }
+        BinaryOp::Mod => {
+            if *rhs == 0 {
+                return None;
+            }
+            lhs.checked_rem(*rhs)?
+        }
+    };
+
+    Some(Value::Int(value))
+}

--- a/src/codegen/inter/opt/copy_prop.rs
+++ b/src/codegen/inter/opt/copy_prop.rs
@@ -1,0 +1,14 @@
+use super::OptPass;
+use crate::codegen::inter::Cfg;
+
+pub struct CopyPropagationPass;
+
+impl OptPass for CopyPropagationPass {
+    fn name(&self) -> &'static str {
+        "copy-propagation"
+    }
+
+    fn run(&self, _cfg: &mut Cfg) -> bool {
+        false
+    }
+}

--- a/src/codegen/inter/opt/cse.rs
+++ b/src/codegen/inter/opt/cse.rs
@@ -1,0 +1,14 @@
+use super::OptPass;
+use crate::codegen::inter::Cfg;
+
+pub struct CsePass;
+
+impl OptPass for CsePass {
+    fn name(&self) -> &'static str {
+        "common-subexpression-elimination"
+    }
+
+    fn run(&self, _cfg: &mut Cfg) -> bool {
+        false
+    }
+}

--- a/src/codegen/inter/opt/dce.rs
+++ b/src/codegen/inter/opt/dce.rs
@@ -1,0 +1,24 @@
+use super::OptPass;
+use crate::codegen::inter::{Cfg, Instruction};
+
+pub struct DeadCodeElimPass;
+
+impl OptPass for DeadCodeElimPass {
+    fn name(&self) -> &'static str {
+        "dead-code-elimination"
+    }
+
+    fn run(&self, cfg: &mut Cfg) -> bool {
+        let mut changed = false;
+
+        for block in &mut cfg.blocks {
+            let before = block.instructions.len();
+            block
+                .instructions
+                .retain(|instruction| !matches!(instruction, Instruction::Nop));
+            changed |= block.instructions.len() != before;
+        }
+
+        changed
+    }
+}

--- a/src/codegen/inter/opt/inline.rs
+++ b/src/codegen/inter/opt/inline.rs
@@ -1,0 +1,14 @@
+use super::OptPass;
+use crate::codegen::inter::Cfg;
+
+pub struct InliningPass;
+
+impl OptPass for InliningPass {
+    fn name(&self) -> &'static str {
+        "inlining"
+    }
+
+    fn run(&self, _cfg: &mut Cfg) -> bool {
+        false
+    }
+}

--- a/src/codegen/inter/opt/licm.rs
+++ b/src/codegen/inter/opt/licm.rs
@@ -1,0 +1,14 @@
+use super::OptPass;
+use crate::codegen::inter::Cfg;
+
+pub struct LoopInvariantCodeMotionPass;
+
+impl OptPass for LoopInvariantCodeMotionPass {
+    fn name(&self) -> &'static str {
+        "loop-invariant-code-motion"
+    }
+
+    fn run(&self, _cfg: &mut Cfg) -> bool {
+        false
+    }
+}

--- a/src/codegen/inter/opt/mod.rs
+++ b/src/codegen/inter/opt/mod.rs
@@ -79,18 +79,13 @@ impl Default for PassManager {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OptLevel {
+    #[default]
     O0,
     O1,
     O2,
     O3,
-}
-
-impl Default for OptLevel {
-    fn default() -> Self {
-        Self::O0
-    }
 }
 
 impl OptLevel {

--- a/src/codegen/inter/opt/mod.rs
+++ b/src/codegen/inter/opt/mod.rs
@@ -1,0 +1,198 @@
+use super::Cfg;
+
+pub mod constant_fold;
+pub mod copy_prop;
+pub mod cse;
+pub mod dce;
+pub mod inline;
+pub mod licm;
+
+pub use constant_fold::ConstantFoldPass;
+pub use copy_prop::CopyPropagationPass;
+pub use cse::CsePass;
+pub use dce::DeadCodeElimPass;
+pub use inline::InliningPass;
+pub use licm::LoopInvariantCodeMotionPass;
+
+/// Interface comum para passes de otimizacao sobre o CFG/TAC intermediario.
+///
+/// Um pass deve retornar `true` quando altera o `Cfg`, permitindo que o
+/// `PassManager` itere ate ponto fixo.
+pub trait OptPass {
+    fn name(&self) -> &'static str;
+
+    fn run(&self, cfg: &mut Cfg) -> bool;
+}
+
+pub struct PassManager {
+    passes: Vec<Box<dyn OptPass>>,
+}
+
+impl PassManager {
+    pub fn new() -> Self {
+        Self { passes: Vec::new() }
+    }
+
+    pub fn add<P: OptPass + 'static>(&mut self, pass: P) {
+        self.passes.push(Box::new(pass));
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.passes.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.passes.len()
+    }
+
+    pub fn pass_names(&self) -> Vec<&'static str> {
+        self.passes.iter().map(|pass| pass.name()).collect()
+    }
+
+    /// Executa todos os passes ate ponto fixo ou `max_iter` iteracoes.
+    ///
+    /// Retorna o numero de iteracoes completas executadas.
+    pub fn run(&self, cfg: &mut Cfg, max_iter: usize) -> usize {
+        let mut iterations = 0;
+
+        for _ in 0..max_iter {
+            let mut changed = false;
+
+            for pass in &self.passes {
+                changed |= pass.run(cfg);
+            }
+
+            iterations += 1;
+
+            if !changed {
+                break;
+            }
+        }
+
+        iterations
+    }
+}
+
+impl Default for PassManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptLevel {
+    O0,
+    O1,
+    O2,
+    O3,
+}
+
+impl Default for OptLevel {
+    fn default() -> Self {
+        Self::O0
+    }
+}
+
+impl OptLevel {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "0" | "O0" | "-O0" => Some(Self::O0),
+            "1" | "O1" | "-O1" => Some(Self::O1),
+            "2" | "O2" | "-O2" => Some(Self::O2),
+            "3" | "O3" | "-O3" => Some(Self::O3),
+            _ => None,
+        }
+    }
+}
+
+pub fn pipeline_for_level(level: OptLevel) -> PassManager {
+    let mut pm = PassManager::new();
+
+    match level {
+        OptLevel::O0 => {}
+        OptLevel::O1 => {
+            pm.add(ConstantFoldPass);
+            pm.add(DeadCodeElimPass);
+        }
+        OptLevel::O2 => {
+            pm.add(ConstantFoldPass);
+            pm.add(DeadCodeElimPass);
+            pm.add(CopyPropagationPass);
+            pm.add(CsePass);
+        }
+        OptLevel::O3 => {
+            pm.add(ConstantFoldPass);
+            pm.add(DeadCodeElimPass);
+            pm.add(CopyPropagationPass);
+            pm.add(CsePass);
+            pm.add(LoopInvariantCodeMotionPass);
+            pm.add(InliningPass);
+        }
+    }
+
+    pm
+}
+
+pub fn default_pipeline() -> PassManager {
+    pipeline_for_level(OptLevel::O2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codegen::inter::{BasicBlock, BinaryOp, Instruction, Value};
+
+    #[test]
+    fn pass_manager_runs_until_fixed_point() {
+        let mut cfg = Cfg::new();
+        let mut block = BasicBlock::new("entry");
+        block.instructions.push(Instruction::Binary {
+            dst: "t0".to_string(),
+            op: BinaryOp::Add,
+            lhs: Value::Int(2),
+            rhs: Value::Int(3),
+        });
+        cfg.add_block(block);
+
+        let mut pm = PassManager::new();
+        pm.add(ConstantFoldPass);
+
+        assert_eq!(pm.run(&mut cfg, 10), 2);
+        assert_eq!(
+            cfg.blocks[0].instructions[0],
+            Instruction::Assign {
+                dst: "t0".to_string(),
+                value: Value::Int(5),
+            }
+        );
+    }
+
+    #[test]
+    fn opt_level_selects_expected_pipeline() {
+        assert!(pipeline_for_level(OptLevel::O0).is_empty());
+        assert_eq!(
+            pipeline_for_level(OptLevel::O1).pass_names(),
+            vec!["constant-fold", "dead-code-elimination"]
+        );
+        assert_eq!(
+            pipeline_for_level(OptLevel::O2).pass_names(),
+            vec![
+                "constant-fold",
+                "dead-code-elimination",
+                "copy-propagation",
+                "common-subexpression-elimination",
+            ]
+        );
+        assert_eq!(
+            pipeline_for_level(OptLevel::O3).pass_names(),
+            vec![
+                "constant-fold",
+                "dead-code-elimination",
+                "copy-propagation",
+                "common-subexpression-elimination",
+                "loop-invariant-code-motion",
+                "inlining",
+            ]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,92 @@
 use crusty::analyser::analyse;
+use crusty::codegen::inter::opt::{pipeline_for_level, OptLevel};
+use crusty::codegen::inter::Cfg;
 use crusty::common::errors::report::{Report, ToReport};
 use crusty::common::input::source::SourceFile;
 use crusty::lexer::scanner::Scanner;
 use crusty::parser::Parser;
 use std::env;
 use std::path::PathBuf;
-use std::process::exit;
 
 /// Ponto de entrada: decide entre modo interativo (sem args) ou compilação de arquivo (1 arg).
 fn main() -> std::io::Result<()> {
     let args: Vec<_> = env::args().collect();
-    match args.len() {
-        1 => {
+    let options = match parse_args(&args) {
+        Ok(options) => options,
+        Err(e) => report_and_exit(Box::new(e)),
+    };
+
+    match options.script {
+        None => {
             if let Err(e) = run_prompt() {
                 report_and_exit(e);
             }
         }
-        2 => {
-            if let Err(e) = run_file(&args[1]) {
+        Some(script) => {
+            if let Err(e) = run_file(&script, options.opt_level) {
                 report_and_exit(e);
             }
         }
-        _ => {
-            eprintln!("Usage: crusty [script]");
-            exit(64);
-        }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompileOptions {
+    script: Option<String>,
+    opt_level: OptLevel,
+}
+
+#[derive(Debug)]
+struct CliError {
+    message: String,
+}
+
+impl ToReport for CliError {
+    fn to_report(&self) -> Report {
+        Report::new(&self.message)
+            .with_help("Usage: crusty [-O0|-O1|-O2|-O3] [--opt-level 0|1|2|3] [script]")
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<CompileOptions, CliError> {
+    let mut opt_level = OptLevel::default();
+    let mut script = None;
+    let mut i = 1;
+
+    while i < args.len() {
+        let arg = &args[i];
+
+        if let Some(level) = arg.strip_prefix("-O").filter(|level| !level.is_empty()) {
+            opt_level = OptLevel::parse(level).ok_or_else(|| CliError {
+                message: format!("invalid optimization level: {arg}"),
+            })?;
+        } else if arg == "-O" || arg == "--opt-level" {
+            i += 1;
+            let Some(level) = args.get(i) else {
+                return Err(CliError {
+                    message: format!("missing value for {arg}"),
+                });
+            };
+            opt_level = OptLevel::parse(level).ok_or_else(|| CliError {
+                message: format!("invalid optimization level: {level}"),
+            })?;
+        } else if arg.starts_with('-') {
+            return Err(CliError {
+                message: format!("unknown option: {arg}"),
+            });
+        } else if script.is_none() {
+            script = Some(arg.clone());
+        } else {
+            return Err(CliError {
+                message: "expected at most one input script".to_string(),
+            });
+        }
+
+        i += 1;
+    }
+
+    Ok(CompileOptions { script, opt_level })
 }
 
 /// Erro retornado por `run()` quando o scanner produz diagnósticos.
@@ -47,7 +107,7 @@ fn run_prompt() -> Result<(), Box<dyn ToReport>> {
 }
 
 /// Executa o scanner e parser sobre o `SourceFile`, imprime tokens e AST.
-fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
+fn run(source: SourceFile, opt_level: OptLevel) -> Result<(), Box<dyn ToReport>> {
     let mut scanner = Scanner::new(source);
     scanner.scan();
 
@@ -105,6 +165,10 @@ fn run(source: SourceFile) -> Result<(), Box<dyn ToReport>> {
         return Err(Box::new(DiagnosticError { count: sem_count }));
     }
 
+    let mut cfg = Cfg::new();
+    let opt_pipeline = pipeline_for_level(opt_level);
+    opt_pipeline.run(&mut cfg, 10);
+
     Ok(())
 }
 
@@ -122,14 +186,14 @@ fn print_report(report: &Report) {
 }
 
 /// Lê o arquivo no caminho informado e delega a execução para `run`.
-fn run_file(path: &str) -> Result<(), Box<dyn ToReport>> {
+fn run_file(path: &str, opt_level: OptLevel) -> Result<(), Box<dyn ToReport>> {
     let source = SourceFile::from_path(PathBuf::from(path))?;
-    run(source)?;
+    run(source, opt_level)?;
     Ok(())
 }
 
 /// Imprime o `Report` de erro no stderr de forma estruturada e encerra o processo com código 74.
-fn report_and_exit(e: Box<dyn ToReport>) {
+fn report_and_exit(e: Box<dyn ToReport>) -> ! {
     let report = e.to_report();
 
     eprintln!("--- ERROR ---");
@@ -144,4 +208,49 @@ fn report_and_exit(e: Box<dyn ToReport>) {
     }
 
     std::process::exit(74);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_default_options() {
+        let parsed = parse_args(&args(&["crusty", "main.c"])).unwrap();
+
+        assert_eq!(
+            parsed,
+            CompileOptions {
+                script: Some("main.c".to_string()),
+                opt_level: OptLevel::O0,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_short_opt_level_forms() {
+        assert_eq!(
+            parse_args(&args(&["crusty", "-O2", "main.c"]))
+                .unwrap()
+                .opt_level,
+            OptLevel::O2
+        );
+        assert_eq!(
+            parse_args(&args(&["crusty", "-O", "3", "main.c"]))
+                .unwrap()
+                .opt_level,
+            OptLevel::O3
+        );
+    }
+
+    #[test]
+    fn parses_long_opt_level_form() {
+        let parsed = parse_args(&args(&["crusty", "--opt-level", "1", "main.c"])).unwrap();
+
+        assert_eq!(parsed.opt_level, OptLevel::O1);
+    }
 }


### PR DESCRIPTION
## Feat(opt): adicionar infraestrutura de passes de otimização

## Descrição

Implementa a infraestrutura da etapa de otimização entre a geração de TAC/CFG e a emissão de assembly.

Este PR introduz uma interface comum para passes de otimização, um gerenciador de passes capaz de executar otimizações até atingir ponto fixo e pipelines de otimização selecionados por meio dos níveis de otimização da CLI.

## Alterações

- [x] Adicionado o trait `OptPass` para passes de otimização do compilador.
- [x] Adicionado o `PassManager` com suporte a:
  - Composição de passes.
  - Iteração até ponto fixo.
  - Limite máximo de iterações (`max_iter`).
- [x] Adicionada a seleção de pipelines de otimização para:
  - `-O0`
  - `-O1`
  - `-O2`
  - `-O3`
- [x] Adicionados os módulos de passes de otimização:
  - `constant_fold`
  - `dce`
  - `copy_prop`
  - `cse`
  - `licm`
  - `inline`
- [x] Implementado o passe `ConstantFoldPass`.
- [x] Implementado um `DeadCodeElimPass` simples para remoção de instruções `Nop`.
- [x] Adicionado um modelo intermediário mínimo de CFG/TAC para permitir testes e futuras extensões da infraestrutura de otimização.
- [x] Adicionado suporte na CLI para:
  - `-O0`, `-O1`, `-O2`, `-O3`
  - `-O 0..3`
  - `--opt-level 0..3`

## Comportamento dos Pipelines

| Nível | Passes |
|--------|---------|
| `-O0` | Nenhuma otimização |
| `-O1` | Constant Folding + DCE |
| `-O2` | `-O1` + Copy Propagation + CSE |
| `-O3` | `-O2` + LICM + Inlining |

## Observações

A geração completa de TAC/CFG ainda não está integrada ao pipeline do compilador. Neste momento, a etapa de otimização opera sobre uma instância vazia de `Cfg`, permitindo validar e evoluir a infraestrutura desenvolvida.

Quando a geração de TAC/CFG for integrada, o mesmo gerenciador de passes e os mesmos pipelines de otimização poderão operar diretamente sobre a representação intermediária gerada.

## Testes

- [x] Executado `cargo fmt`
- [x] Executado `cargo test`

Todos os testes foram concluídos com sucesso.