### PR TITLE
feat(ir): adiciona infraestrutura inicial da representação intermediária TAC

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,0 +1,1 @@
+pub mod tac;

--- a/src/ir/tac.rs
+++ b/src/ir/tac.rs
@@ -1,0 +1,51 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TempId(pub u32);
+
+#[derive(Debug, Clone)]
+pub struct TempGen {
+    next: u32,
+}
+
+impl TempGen {
+    pub fn new() -> Self {
+        Self { next: 0 }
+    }
+
+    pub fn fresh(&mut self) -> TempId {
+        let temp = TempId(self.next);
+        self.next += 1;
+        temp
+    }
+}
+
+impl Default for TempGen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LabelId(pub u32);
+
+#[derive(Debug, Clone)]
+pub struct LabelGen {
+    next: u32,
+}
+
+impl LabelGen {
+    pub fn new() -> Self {
+        Self { next: 0 }
+    }
+
+    pub fn fresh(&mut self) -> LabelId {
+        let label = LabelId(self.next);
+        self.next += 1;
+        label
+    }
+}
+
+impl Default for LabelGen {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/ir/tac.rs
+++ b/src/ir/tac.rs
@@ -1,3 +1,5 @@
+use crate::common::ast::expr::{BinOp, UnOp};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TempId(pub u32);
 
@@ -48,4 +50,67 @@ impl Default for LabelGen {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConstValue {
+    Int(i64),
+    Double(f64),
+    Char(char),
+    String(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operand {
+    Temp(TempId),
+    Var(String),
+    Const(ConstValue),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TacInstr {
+    BinOp {
+        dst: TempId,
+        op: BinOp,
+        lhs: Operand,
+        rhs: Operand,
+    },
+    UnOp {
+        dst: TempId,
+        op: UnOp,
+        src: Operand,
+    },
+    Copy {
+        dst: TempId,
+        src: Operand,
+    },
+    Jump {
+        label: LabelId,
+    },
+    CondJump {
+        cond: Operand,
+        then_label: LabelId,
+        else_label: LabelId,
+    },
+    Call {
+        dst: Option<TempId>,
+        fn_name: String,
+        args: Vec<Operand>,
+    },
+    Return {
+        val: Option<Operand>,
+    },
+    Label(LabelId),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TacFunction {
+    pub name: String,
+    pub params: Vec<String>,
+    pub instrs: Vec<TacInstr>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TacProgram {
+    pub functions: Vec<TacFunction>,
 }

--- a/src/ir/tac.rs
+++ b/src/ir/tac.rs
@@ -166,11 +166,7 @@ impl fmt::Display for TacInstr {
                 then_label,
                 else_label,
             } => write!(f, "if {cond} goto {then_label} else goto {else_label}"),
-            TacInstr::Call {
-                dst,
-                fn_name,
-                args,
-            } => {
+            TacInstr::Call { dst, fn_name, args } => {
                 if let Some(dst) = dst {
                     write!(f, "{dst} = ")?;
                 }

--- a/src/ir/tac.rs
+++ b/src/ir/tac.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::common::ast::expr::{BinOp, UnOp};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -113,4 +115,116 @@ pub struct TacFunction {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TacProgram {
     pub functions: Vec<TacFunction>,
+}
+
+impl fmt::Display for TempId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "t{}", self.0)
+    }
+}
+
+impl fmt::Display for LabelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+impl fmt::Display for ConstValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConstValue::Int(value) => write!(f, "{value}"),
+            ConstValue::Double(value) => write!(f, "{value}"),
+            ConstValue::Char(value) => write!(f, "{value:?}"),
+            ConstValue::String(value) => write!(f, "{value:?}"),
+        }
+    }
+}
+
+impl fmt::Display for Operand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Operand::Temp(temp) => write!(f, "{temp}"),
+            Operand::Var(name) => write!(f, "{name}"),
+            Operand::Const(value) => write!(f, "{value}"),
+        }
+    }
+}
+
+impl fmt::Display for TacInstr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TacInstr::BinOp { dst, op, lhs, rhs } => {
+                write!(f, "{dst} = {lhs} {} {rhs}", bin_op_symbol(op))
+            }
+            TacInstr::UnOp { dst, op, src } => {
+                write!(f, "{dst} = {}{src}", un_op_symbol(op))
+            }
+            TacInstr::Copy { dst, src } => write!(f, "{dst} = {src}"),
+            TacInstr::Jump { label } => write!(f, "goto {label}"),
+            TacInstr::CondJump {
+                cond,
+                then_label,
+                else_label,
+            } => write!(f, "if {cond} goto {then_label} else goto {else_label}"),
+            TacInstr::Call {
+                dst,
+                fn_name,
+                args,
+            } => {
+                if let Some(dst) = dst {
+                    write!(f, "{dst} = ")?;
+                }
+
+                write!(f, "call {fn_name}(")?;
+                for (index, arg) in args.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{arg}")?;
+                }
+                write!(f, ")")
+            }
+            TacInstr::Return { val } => {
+                if let Some(val) = val {
+                    write!(f, "return {val}")
+                } else {
+                    write!(f, "return")
+                }
+            }
+            TacInstr::Label(label) => write!(f, "{label}:"),
+        }
+    }
+}
+
+fn bin_op_symbol(op: &BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+        BinOp::Mod => "%",
+        BinOp::Eq => "==",
+        BinOp::Neq => "!=",
+        BinOp::Less => "<",
+        BinOp::Greater => ">",
+        BinOp::Leq => "<=",
+        BinOp::Geq => ">=",
+        BinOp::And => "&&",
+        BinOp::Or => "||",
+        BinOp::BitAnd => "&",
+        BinOp::BitOr => "|",
+        BinOp::BitXor => "^",
+        BinOp::Shl => "<<",
+        BinOp::Shr => ">>",
+    }
+}
+
+fn un_op_symbol(op: &UnOp) -> &'static str {
+    match op {
+        UnOp::Neg => "-",
+        UnOp::Not => "!",
+        UnOp::BitNot => "~",
+        UnOp::Deref => "*",
+        UnOp::AddrOf => "&",
+    }
 }

--- a/src/ir/tac.rs
+++ b/src/ir/tac.rs
@@ -228,3 +228,36 @@ fn un_op_symbol(op: &UnOp) -> &'static str {
         UnOp::AddrOf => "&",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tac_instr_display_binop() {
+        let instr = TacInstr::BinOp {
+            dst: TempId(0),
+            op: BinOp::Add,
+            lhs: Operand::Temp(TempId(1)),
+            rhs: Operand::Temp(TempId(2)),
+        };
+
+        assert_eq!(instr.to_string(), "t0 = t1 + t2");
+    }
+
+    #[test]
+    fn temp_gen_increments() {
+        let mut gen = TempGen::new();
+
+        assert_eq!(gen.fresh(), TempId(0));
+        assert_eq!(gen.fresh(), TempId(1));
+    }
+
+    #[test]
+    fn label_gen_unique() {
+        let mut gen = LabelGen::new();
+
+        assert_eq!(gen.fresh(), LabelId(0));
+        assert_eq!(gen.fresh(), LabelId(1));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod analyser;
 pub mod codegen;
 pub mod common;
+pub mod ir;
 pub mod lexer;
 pub mod parser;
 


### PR DESCRIPTION
## Título

feat(ir): adiciona infraestrutura inicial da representação intermediária TAC

## Descrição

Este Pull Request introduz a primeira versão da representação intermediária (IR) baseada em **Three-Address Code (TAC)**, estabelecendo a base para as próximas etapas do compilador, como geração de CFG, otimizações e emissão de código.

A implementação está localizada em `src/ir/tac.rs` e define as estruturas fundamentais para modelar programas em TAC, incluindo operandos, instruções, funções, programas, temporários e labels.

## O que foi adicionado

- Exposição do módulo público `ir`
- Criação do arquivo `src/ir/tac.rs`
- Geradores de identificadores para temporários:
  - `TempId`
  - `TempGen`
- Geradores de identificadores para labels:
  - `LabelId`
  - `LabelGen`
- Estruturas para representação de valores e operandos:
  - `ConstValue`
  - `Operand`
- Definição do conjunto de instruções TAC:
  - `TacInstr`
- Estruturas de nível superior da IR:
  - `TacFunction`
  - `TacProgram`
- Implementação de `Display` para visualização legível das instruções TAC
- Cobertura de testes unitários para os componentes básicos da IR

## Testes adicionados

- Impressão de instruções binárias
- Geração sequencial de temporários
- Geração e unicidade de labels

## Exemplo

Entrada interna:

```text
Add(t0, t1, t2)