### PR TITLE
Feat(ir): lowering da AST para TAC

### DIFF
--- a/src/ir/cfg.rs
+++ b/src/ir/cfg.rs
@@ -184,11 +184,11 @@ mod tests {
     fn straight_line_code_is_one_block() {
         let f = func(vec![
             TacInstr::Copy {
-                dst: TempId(0),
+                dst: Operand::Temp(TempId(0)),
                 src: Operand::Const(ConstValue::Int(1)),
             },
             TacInstr::Copy {
-                dst: TempId(1),
+                dst: Operand::Temp(TempId(1)),
                 src: Operand::Const(ConstValue::Int(2)),
             },
             TacInstr::Return {
@@ -216,13 +216,13 @@ mod tests {
             },
             TacInstr::Label(then_label),
             TacInstr::Copy {
-                dst: TempId(0),
+                dst: Operand::Temp(TempId(0)),
                 src: Operand::Const(ConstValue::Int(1)),
             },
             TacInstr::Jump { label: merge_label },
             TacInstr::Label(else_label),
             TacInstr::Copy {
-                dst: TempId(0),
+                dst: Operand::Temp(TempId(0)),
                 src: Operand::Const(ConstValue::Int(2)),
             },
             TacInstr::Label(merge_label),
@@ -252,7 +252,7 @@ mod tests {
             },
             TacInstr::Label(body_label),
             TacInstr::Copy {
-                dst: TempId(0),
+                dst: Operand::Temp(TempId(0)),
                 src: Operand::Const(ConstValue::Int(1)),
             },
             TacInstr::Jump { label: cond_label },

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1,7 +1,7 @@
 use crate::common::ast::{
-    ast::Program,
+    ast::{Program, Type},
     decl::Decl,
-    expr::{Expr, Literal},
+    expr::{BinOp, Expr, Literal, PostfixOp, PrefixOp},
     stmt::Stmt,
 };
 use crate::ir::tac::{
@@ -56,6 +56,8 @@ impl Lowerer {
                 });
                 Operand::Temp(dst)
             }
+            Expr::Prefix(op, target, _) => self.lower_prefix(op, target),
+            Expr::Postfix(op, target, _) => self.lower_postfix(op, target),
             Expr::Call(callee, args, _) => {
                 let fn_name = match callee.as_ref() {
                     Expr::Ident(name, _) => name.clone(),
@@ -77,7 +79,48 @@ impl Lowerer {
                 self.emit_copy(dst.clone(), src);
                 dst
             }
-            _ => panic!("lowering ainda nao suporta essa expressao"),
+            Expr::CompoundAssign(op, lhs, rhs, _) => {
+                let dst = self.lower_assignment_target(lhs);
+                let rhs = self.lower_expr(rhs);
+                let temp = self.fresh_temp();
+                self.instrs.push(TacInstr::BinOp {
+                    dst: temp,
+                    op: op.clone(),
+                    lhs: dst.clone(),
+                    rhs,
+                });
+                self.emit_copy(dst.clone(), Operand::Temp(temp));
+                dst
+            }
+            Expr::SizeofType(qty, _) => Operand::Const(ConstValue::Int(type_size(&qty.ty))),
+            Expr::Ternary(cond, then_expr, else_expr, _) => {
+                let cond = self.lower_expr(cond);
+                let then_label = self.labels.fresh();
+                let else_label = self.labels.fresh();
+                let end_label = self.labels.fresh();
+                let dst = self.fresh_temp();
+
+                self.instrs.push(TacInstr::CondJump {
+                    cond,
+                    then_label,
+                    else_label,
+                });
+
+                self.instrs.push(TacInstr::Label(then_label));
+                let then_val = self.lower_expr(then_expr);
+                self.emit_copy(Operand::Temp(dst), then_val);
+                self.emit_jump_unless_terminated(end_label);
+
+                self.instrs.push(TacInstr::Label(else_label));
+                let else_val = self.lower_expr(else_expr);
+                self.emit_copy(Operand::Temp(dst), else_val);
+
+                self.instrs.push(TacInstr::Label(end_label));
+                Operand::Temp(dst)
+            }
+            Expr::Index(_, _, _) => panic!("lowering ainda nao suporta acesso por indice"),
+            Expr::Member(_, _, _, _) => panic!("lowering ainda nao suporta acesso a membro"),
+            Expr::Sizeof(_, _) => panic!("lowering de sizeof(expr) requer informacao de tipo"),
         }
     }
 
@@ -228,7 +271,7 @@ impl Lowerer {
                     self.emit_copy(Operand::Var(name.clone()), src);
                 }
             }
-            _ => panic!("lowering ainda nao suporta esse statement"),
+            Stmt::Switch(_, _, _) => panic!("lowering ainda nao suporta switch"),
         }
     }
 
@@ -238,6 +281,35 @@ impl Lowerer {
 
     fn fresh_temp(&mut self) -> TempId {
         self.temps.fresh()
+    }
+
+    fn lower_prefix(&mut self, op: &PrefixOp, target: &Expr) -> Operand {
+        let dst = self.lower_assignment_target(target);
+        let temp = self.fresh_temp();
+        self.instrs.push(TacInstr::BinOp {
+            dst: temp,
+            op: prefix_bin_op(op),
+            lhs: dst.clone(),
+            rhs: Operand::Const(ConstValue::Int(1)),
+        });
+        self.emit_copy(dst.clone(), Operand::Temp(temp));
+        dst
+    }
+
+    fn lower_postfix(&mut self, op: &PostfixOp, target: &Expr) -> Operand {
+        let dst = self.lower_assignment_target(target);
+        let old = self.fresh_temp();
+        self.emit_copy(Operand::Temp(old), dst.clone());
+
+        let new = self.fresh_temp();
+        self.instrs.push(TacInstr::BinOp {
+            dst: new,
+            op: postfix_bin_op(op),
+            lhs: dst.clone(),
+            rhs: Operand::Const(ConstValue::Int(1)),
+        });
+        self.emit_copy(dst, Operand::Temp(new));
+        Operand::Temp(old)
     }
 
     fn lower_assignment_target(&mut self, expr: &Expr) -> Operand {
@@ -305,5 +377,31 @@ fn lower_literal(value: &Literal) -> ConstValue {
         Literal::Double(value) => ConstValue::Double(*value),
         Literal::Char(value) => ConstValue::Char(*value),
         Literal::String(value) => ConstValue::String(value.clone()),
+    }
+}
+
+fn prefix_bin_op(op: &PrefixOp) -> BinOp {
+    match op {
+        PrefixOp::Inc => BinOp::Add,
+        PrefixOp::Dec => BinOp::Sub,
+    }
+}
+
+fn postfix_bin_op(op: &PostfixOp) -> BinOp {
+    match op {
+        PostfixOp::Inc => BinOp::Add,
+        PostfixOp::Dec => BinOp::Sub,
+    }
+}
+
+fn type_size(ty: &Type) -> i64 {
+    match ty {
+        Type::Char => 1,
+        Type::Short => 2,
+        Type::Int | Type::Float | Type::Enum(_) => 4,
+        Type::Long | Type::Double | Type::Pointer(_) => 8,
+        Type::Array(_) | Type::Void | Type::Struct(_) | Type::Alias(_) | Type::Function(_, _) => {
+            panic!("lowering de sizeof(type) requer layout/tamanho completo")
+        }
     }
 }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -100,6 +100,25 @@ impl Lowerer {
                 }
                 self.instrs.push(TacInstr::Label(end_label));
             }
+            Stmt::While(cond, body, _) => {
+                let cond_label = self.labels.fresh();
+                let body_label = self.labels.fresh();
+                let end_label = self.labels.fresh();
+
+                self.instrs.push(TacInstr::Label(cond_label));
+                let cond = self.lower_expr(cond);
+                self.instrs.push(TacInstr::CondJump {
+                    cond,
+                    then_label: body_label,
+                    else_label: end_label,
+                });
+
+                self.instrs.push(TacInstr::Label(body_label));
+                self.lower_stmt(body);
+                self.emit_jump_unless_terminated(cond_label);
+
+                self.instrs.push(TacInstr::Label(end_label));
+            }
             Stmt::ExprStmt(expr, _) => {
                 self.lower_expr(expr);
             }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2,7 +2,7 @@ use crate::common::ast::{
     expr::{Expr, Literal},
     stmt::Stmt,
 };
-use crate::ir::tac::{ConstValue, LabelGen, Operand, TacInstr, TempGen, TempId};
+use crate::ir::tac::{ConstValue, LabelGen, LabelId, Operand, TacInstr, TempGen, TempId};
 
 #[derive(Debug, Clone)]
 pub struct Lowerer {
@@ -78,6 +78,28 @@ impl Lowerer {
                     self.lower_stmt(stmt);
                 }
             }
+            Stmt::If(cond, then_branch, else_branch, _) => {
+                let cond = self.lower_expr(cond);
+                let then_label = self.labels.fresh();
+                let else_label = self.labels.fresh();
+                let end_label = self.labels.fresh();
+
+                self.instrs.push(TacInstr::CondJump {
+                    cond,
+                    then_label,
+                    else_label,
+                });
+
+                self.instrs.push(TacInstr::Label(then_label));
+                self.lower_stmt(then_branch);
+                self.emit_jump_unless_terminated(end_label);
+
+                self.instrs.push(TacInstr::Label(else_label));
+                if let Some(else_branch) = else_branch {
+                    self.lower_stmt(else_branch);
+                }
+                self.instrs.push(TacInstr::Label(end_label));
+            }
             Stmt::ExprStmt(expr, _) => {
                 self.lower_expr(expr);
             }
@@ -114,6 +136,15 @@ impl Lowerer {
         match dst {
             Operand::Temp(_) | Operand::Var(_) => self.instrs.push(TacInstr::Copy { dst, src }),
             Operand::Const(_) => panic!("constante nao pode ser destino de copia"),
+        }
+    }
+
+    fn emit_jump_unless_terminated(&mut self, label: LabelId) {
+        if !matches!(
+            self.instrs.last(),
+            Some(TacInstr::Jump { .. } | TacInstr::Return { .. })
+        ) {
+            self.instrs.push(TacInstr::Jump { label });
         }
     }
 }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -139,6 +139,70 @@ impl Lowerer {
 
                 self.instrs.push(TacInstr::Label(end_label));
             }
+            Stmt::For(init, cond, inc, body, _) => {
+                if let Some(init) = init {
+                    self.lower_stmt_with_control(init, control);
+                }
+
+                let cond_label = self.labels.fresh();
+                let body_label = self.labels.fresh();
+                let inc_label = inc.as_ref().map(|_| self.labels.fresh());
+                let end_label = self.labels.fresh();
+                let continue_label = inc_label.unwrap_or(cond_label);
+
+                self.instrs.push(TacInstr::Label(cond_label));
+                if let Some(cond) = cond {
+                    let cond = self.lower_expr(cond);
+                    self.instrs.push(TacInstr::CondJump {
+                        cond,
+                        then_label: body_label,
+                        else_label: end_label,
+                    });
+                }
+
+                self.instrs.push(TacInstr::Label(body_label));
+                self.lower_stmt_with_control(
+                    body,
+                    ControlLabels {
+                        break_label: Some(end_label),
+                        continue_label: Some(continue_label),
+                    },
+                );
+
+                if let Some(inc_label) = inc_label {
+                    self.instrs.push(TacInstr::Label(inc_label));
+                    if let Some(inc) = inc {
+                        self.lower_expr(inc);
+                    }
+                }
+                self.emit_jump_unless_terminated(cond_label);
+
+                self.instrs.push(TacInstr::Label(end_label));
+            }
+            Stmt::DoWhile(cond, body, _) => {
+                let body_label = self.labels.fresh();
+                let cond_label = self.labels.fresh();
+                let end_label = self.labels.fresh();
+
+                self.instrs.push(TacInstr::Label(body_label));
+                self.lower_stmt_with_control(
+                    body,
+                    ControlLabels {
+                        break_label: Some(end_label),
+                        continue_label: Some(cond_label),
+                    },
+                );
+
+                self.instrs.push(TacInstr::Label(cond_label));
+                let cond = self.lower_expr(cond);
+                self.instrs.push(TacInstr::CondJump {
+                    cond,
+                    then_label: body_label,
+                    else_label: end_label,
+                });
+
+                self.instrs.push(TacInstr::Label(end_label));
+            }
             Stmt::Break(_) => {
                 let label = control
                     .break_label

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1,0 +1,53 @@
+use crate::common::ast::{
+    expr::{Expr, Literal},
+    stmt::Stmt,
+};
+use crate::ir::tac::{ConstValue, LabelGen, Operand, TacInstr, TempGen};
+
+#[derive(Debug, Clone)]
+pub struct Lowerer {
+    temps: TempGen,
+    labels: LabelGen,
+    instrs: Vec<TacInstr>,
+}
+
+impl Lowerer {
+    pub fn new() -> Self {
+        Self {
+            temps: TempGen::new(),
+            labels: LabelGen::new(),
+            instrs: Vec::new(),
+        }
+    }
+
+    pub fn lower_expr(&mut self, expr: &Expr) -> Operand {
+        match expr {
+            Expr::Literal(value, _) => Operand::Const(lower_literal(value)),
+            Expr::Ident(name, _) => Operand::Var(name.clone()),
+            _ => panic!("lowering ainda nao suporta essa expressao"),
+        }
+    }
+
+    pub fn lower_stmt(&mut self, _stmt: &Stmt) {
+        panic!("lowering ainda nao suporta esse statement");
+    }
+
+    pub fn finish(self) -> Vec<TacInstr> {
+        self.instrs
+    }
+}
+
+impl Default for Lowerer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn lower_literal(value: &Literal) -> ConstValue {
+    match value {
+        Literal::Int(value) => ConstValue::Int(*value),
+        Literal::Double(value) => ConstValue::Double(*value),
+        Literal::Char(value) => ConstValue::Char(*value),
+        Literal::String(value) => ConstValue::String(value.clone()),
+    }
+}

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -1,8 +1,12 @@
 use crate::common::ast::{
+    ast::Program,
+    decl::Decl,
     expr::{Expr, Literal},
     stmt::Stmt,
 };
-use crate::ir::tac::{ConstValue, LabelGen, LabelId, Operand, TacInstr, TempGen, TempId};
+use crate::ir::tac::{
+    ConstValue, LabelGen, LabelId, Operand, TacFunction, TacInstr, TacProgram, TempGen, TempId,
+};
 
 #[derive(Debug, Clone)]
 pub struct Lowerer {
@@ -171,6 +175,35 @@ impl Lowerer {
 impl Default for Lowerer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub fn lower_function(decl: &Decl) -> TacFunction {
+    match decl {
+        Decl::Function(_, name, params, body, _) => {
+            let mut lowerer = Lowerer::new();
+            for stmt in body {
+                lowerer.lower_stmt(stmt);
+            }
+
+            TacFunction {
+                name: name.clone(),
+                params: params.iter().map(|(_, name)| name.clone()).collect(),
+                instrs: lowerer.finish(),
+            }
+        }
+        _ => panic!("lower_function espera Decl::Function"),
+    }
+}
+
+pub fn lower_program(prog: &Program) -> TacProgram {
+    TacProgram {
+        functions: prog
+            .decls
+            .iter()
+            .filter(|decl| matches!(decl, Decl::Function(..)))
+            .map(lower_function)
+            .collect(),
     }
 }
 

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -36,6 +36,16 @@ impl Lowerer {
                 });
                 Operand::Temp(dst)
             }
+            Expr::Unary(op, src, _) => {
+                let src = self.lower_expr(src);
+                let dst = self.fresh_temp();
+                self.instrs.push(TacInstr::UnOp {
+                    dst,
+                    op: op.clone(),
+                    src,
+                });
+                Operand::Temp(dst)
+            }
             _ => panic!("lowering ainda nao suporta essa expressao"),
         }
     }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -71,8 +71,28 @@ impl Lowerer {
         }
     }
 
-    pub fn lower_stmt(&mut self, _stmt: &Stmt) {
-        panic!("lowering ainda nao suporta esse statement");
+    pub fn lower_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Block(stmts, _) => {
+                for stmt in stmts {
+                    self.lower_stmt(stmt);
+                }
+            }
+            Stmt::ExprStmt(expr, _) => {
+                self.lower_expr(expr);
+            }
+            Stmt::Return(expr, _) => {
+                let val = expr.as_ref().map(|expr| self.lower_expr(expr));
+                self.instrs.push(TacInstr::Return { val });
+            }
+            Stmt::VarDecl(_, name, init, _) => {
+                if let Some(init) = init {
+                    let src = self.lower_expr(init);
+                    self.emit_copy(Operand::Var(name.clone()), src);
+                }
+            }
+            _ => panic!("lowering ainda nao suporta esse statement"),
+        }
     }
 
     pub fn finish(self) -> Vec<TacInstr> {

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -15,6 +15,12 @@ pub struct Lowerer {
     instrs: Vec<TacInstr>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct ControlLabels {
+    break_label: Option<LabelId>,
+    continue_label: Option<LabelId>,
+}
+
 impl Lowerer {
     pub fn new() -> Self {
         Self {
@@ -76,10 +82,14 @@ impl Lowerer {
     }
 
     pub fn lower_stmt(&mut self, stmt: &Stmt) {
+        self.lower_stmt_with_control(stmt, ControlLabels::default());
+    }
+
+    fn lower_stmt_with_control(&mut self, stmt: &Stmt, control: ControlLabels) {
         match stmt {
             Stmt::Block(stmts, _) => {
                 for stmt in stmts {
-                    self.lower_stmt(stmt);
+                    self.lower_stmt_with_control(stmt, control);
                 }
             }
             Stmt::If(cond, then_branch, else_branch, _) => {
@@ -95,12 +105,12 @@ impl Lowerer {
                 });
 
                 self.instrs.push(TacInstr::Label(then_label));
-                self.lower_stmt(then_branch);
+                self.lower_stmt_with_control(then_branch, control);
                 self.emit_jump_unless_terminated(end_label);
 
                 self.instrs.push(TacInstr::Label(else_label));
                 if let Some(else_branch) = else_branch {
-                    self.lower_stmt(else_branch);
+                    self.lower_stmt_with_control(else_branch, control);
                 }
                 self.instrs.push(TacInstr::Label(end_label));
             }
@@ -118,10 +128,28 @@ impl Lowerer {
                 });
 
                 self.instrs.push(TacInstr::Label(body_label));
-                self.lower_stmt(body);
+                self.lower_stmt_with_control(
+                    body,
+                    ControlLabels {
+                        break_label: Some(end_label),
+                        continue_label: Some(cond_label),
+                    },
+                );
                 self.emit_jump_unless_terminated(cond_label);
 
                 self.instrs.push(TacInstr::Label(end_label));
+            }
+            Stmt::Break(_) => {
+                let label = control
+                    .break_label
+                    .expect("break fora de loop/switch nao pode ser baixado");
+                self.instrs.push(TacInstr::Jump { label });
+            }
+            Stmt::Continue(_) => {
+                let label = control
+                    .continue_label
+                    .expect("continue fora de loop nao pode ser baixado");
+                self.instrs.push(TacInstr::Jump { label });
             }
             Stmt::ExprStmt(expr, _) => {
                 self.lower_expr(expr);

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -61,6 +61,12 @@ impl Lowerer {
                 Operand::Temp(dst)
             }
             Expr::Cast(_, inner, _) => self.lower_expr(inner),
+            Expr::Assign(lhs, rhs, _) => {
+                let src = self.lower_expr(rhs);
+                let dst = self.lower_assignment_target(lhs);
+                self.emit_copy(dst.clone(), src);
+                dst
+            }
             _ => panic!("lowering ainda nao suporta essa expressao"),
         }
     }
@@ -75,6 +81,20 @@ impl Lowerer {
 
     fn fresh_temp(&mut self) -> TempId {
         self.temps.fresh()
+    }
+
+    fn lower_assignment_target(&mut self, expr: &Expr) -> Operand {
+        match expr {
+            Expr::Ident(name, _) => Operand::Var(name.clone()),
+            _ => panic!("lowering ainda nao suporta esse destino de atribuicao"),
+        }
+    }
+
+    fn emit_copy(&mut self, dst: Operand, src: Operand) {
+        match dst {
+            Operand::Temp(_) | Operand::Var(_) => self.instrs.push(TacInstr::Copy { dst, src }),
+            Operand::Const(_) => panic!("constante nao pode ser destino de copia"),
+        }
     }
 }
 

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -405,3 +405,208 @@ fn type_size(ty: &Type) -> i64 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{
+        ast::ast::{QualifierType, Type},
+        errors::error_data::Span,
+    };
+
+    fn span() -> Span {
+        Span {
+            line: 1,
+            end_line: 1,
+            column_start: 1,
+            column_end: 1,
+        }
+    }
+
+    fn int_ty() -> QualifierType {
+        QualifierType {
+            ty: Type::Int,
+            is_const: false,
+            is_unsigned: false,
+        }
+    }
+
+    fn int(value: i64) -> Expr {
+        Expr::Literal(Literal::Int(value), span())
+    }
+
+    fn ident(name: &str) -> Expr {
+        Expr::Ident(name.to_string(), span())
+    }
+
+    #[test]
+    fn lower_binary_expr_produces_temp() {
+        let expr = Expr::Binary(Box::new(int(2)), BinOp::Add, Box::new(int(3)), span());
+        let mut lowerer = Lowerer::new();
+
+        let result = lowerer.lower_expr(&expr);
+
+        assert_eq!(result, Operand::Temp(TempId(0)));
+        assert_eq!(
+            lowerer.finish(),
+            vec![TacInstr::BinOp {
+                dst: TempId(0),
+                op: BinOp::Add,
+                lhs: Operand::Const(ConstValue::Int(2)),
+                rhs: Operand::Const(ConstValue::Int(3)),
+            }]
+        );
+    }
+
+    #[test]
+    fn lower_if_else_produces_labels() {
+        let stmt = Stmt::If(
+            int(1),
+            Box::new(Stmt::VarDecl(
+                int_ty(),
+                "x".to_string(),
+                Some(int(2)),
+                span(),
+            )),
+            Some(Box::new(Stmt::VarDecl(
+                int_ty(),
+                "y".to_string(),
+                Some(int(3)),
+                span(),
+            ))),
+            span(),
+        );
+        let mut lowerer = Lowerer::new();
+
+        lowerer.lower_stmt(&stmt);
+        let instrs = lowerer.finish();
+
+        assert!(matches!(
+            instrs[0],
+            TacInstr::CondJump {
+                then_label: LabelId(0),
+                else_label: LabelId(1),
+                ..
+            }
+        ));
+        assert_eq!(instrs[1], TacInstr::Label(LabelId(0)));
+        assert_eq!(
+            instrs[2],
+            TacInstr::Copy {
+                dst: Operand::Var("x".to_string()),
+                src: Operand::Const(ConstValue::Int(2)),
+            }
+        );
+        assert_eq!(instrs[3], TacInstr::Jump { label: LabelId(2) });
+        assert_eq!(instrs[4], TacInstr::Label(LabelId(1)));
+        assert_eq!(
+            instrs[5],
+            TacInstr::Copy {
+                dst: Operand::Var("y".to_string()),
+                src: Operand::Const(ConstValue::Int(3)),
+            }
+        );
+        assert_eq!(instrs[6], TacInstr::Label(LabelId(2)));
+    }
+
+    #[test]
+    fn lower_while_produces_backedge() {
+        let stmt = Stmt::While(
+            ident("keep_going"),
+            Box::new(Stmt::VarDecl(
+                int_ty(),
+                "x".to_string(),
+                Some(int(1)),
+                span(),
+            )),
+            span(),
+        );
+        let mut lowerer = Lowerer::new();
+
+        lowerer.lower_stmt(&stmt);
+        let instrs = lowerer.finish();
+
+        assert_eq!(instrs[0], TacInstr::Label(LabelId(0)));
+        assert!(matches!(
+            instrs[1],
+            TacInstr::CondJump {
+                then_label: LabelId(1),
+                else_label: LabelId(2),
+                ..
+            }
+        ));
+        assert_eq!(instrs[2], TacInstr::Label(LabelId(1)));
+        assert_eq!(instrs[4], TacInstr::Jump { label: LabelId(0) });
+        assert_eq!(instrs[5], TacInstr::Label(LabelId(2)));
+    }
+
+    #[test]
+    fn lower_function_call_passes_args() {
+        let arg0 = Expr::Binary(Box::new(int(1)), BinOp::Add, Box::new(int(2)), span());
+        let expr = Expr::Call(Box::new(ident("sum")), vec![arg0, int(3)], span());
+        let mut lowerer = Lowerer::new();
+
+        let result = lowerer.lower_expr(&expr);
+        let instrs = lowerer.finish();
+
+        assert_eq!(result, Operand::Temp(TempId(1)));
+        assert_eq!(
+            instrs[1],
+            TacInstr::Call {
+                dst: Some(TempId(1)),
+                fn_name: "sum".to_string(),
+                args: vec![Operand::Temp(TempId(0)), Operand::Const(ConstValue::Int(3))],
+            }
+        );
+    }
+
+    #[test]
+    fn lower_nested_expr_correct_temp_order() {
+        let rhs = Expr::Binary(Box::new(int(3)), BinOp::Mul, Box::new(int(4)), span());
+        let expr = Expr::Binary(Box::new(int(2)), BinOp::Add, Box::new(rhs), span());
+        let mut lowerer = Lowerer::new();
+
+        let result = lowerer.lower_expr(&expr);
+
+        assert_eq!(result, Operand::Temp(TempId(1)));
+        assert_eq!(
+            lowerer.finish(),
+            vec![
+                TacInstr::BinOp {
+                    dst: TempId(0),
+                    op: BinOp::Mul,
+                    lhs: Operand::Const(ConstValue::Int(3)),
+                    rhs: Operand::Const(ConstValue::Int(4)),
+                },
+                TacInstr::BinOp {
+                    dst: TempId(1),
+                    op: BinOp::Add,
+                    lhs: Operand::Const(ConstValue::Int(2)),
+                    rhs: Operand::Temp(TempId(0)),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn lower_function_keeps_name_params_and_body() {
+        let decl = Decl::Function(
+            int_ty(),
+            "main".to_string(),
+            vec![(int_ty(), "argc".to_string())],
+            vec![Stmt::Return(Some(ident("argc")), span())],
+            span(),
+        );
+
+        let func = lower_function(&decl);
+
+        assert_eq!(func.name, "main");
+        assert_eq!(func.params, vec!["argc"]);
+        assert_eq!(
+            func.instrs,
+            vec![TacInstr::Return {
+                val: Some(Operand::Var("argc".to_string()))
+            }]
+        );
+    }
+}

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -46,6 +46,21 @@ impl Lowerer {
                 });
                 Operand::Temp(dst)
             }
+            Expr::Call(callee, args, _) => {
+                let fn_name = match callee.as_ref() {
+                    Expr::Ident(name, _) => name.clone(),
+                    _ => panic!("lowering ainda nao suporta chamada por expressao"),
+                };
+                let args = args.iter().map(|arg| self.lower_expr(arg)).collect();
+                let dst = self.fresh_temp();
+                self.instrs.push(TacInstr::Call {
+                    dst: Some(dst),
+                    fn_name,
+                    args,
+                });
+                Operand::Temp(dst)
+            }
+            Expr::Cast(_, inner, _) => self.lower_expr(inner),
             _ => panic!("lowering ainda nao suporta essa expressao"),
         }
     }

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -2,7 +2,7 @@ use crate::common::ast::{
     expr::{Expr, Literal},
     stmt::Stmt,
 };
-use crate::ir::tac::{ConstValue, LabelGen, Operand, TacInstr, TempGen};
+use crate::ir::tac::{ConstValue, LabelGen, Operand, TacInstr, TempGen, TempId};
 
 #[derive(Debug, Clone)]
 pub struct Lowerer {
@@ -24,6 +24,18 @@ impl Lowerer {
         match expr {
             Expr::Literal(value, _) => Operand::Const(lower_literal(value)),
             Expr::Ident(name, _) => Operand::Var(name.clone()),
+            Expr::Binary(lhs, op, rhs, _) => {
+                let lhs = self.lower_expr(lhs);
+                let rhs = self.lower_expr(rhs);
+                let dst = self.fresh_temp();
+                self.instrs.push(TacInstr::BinOp {
+                    dst,
+                    op: op.clone(),
+                    lhs,
+                    rhs,
+                });
+                Operand::Temp(dst)
+            }
             _ => panic!("lowering ainda nao suporta essa expressao"),
         }
     }
@@ -34,6 +46,10 @@ impl Lowerer {
 
     pub fn finish(self) -> Vec<TacInstr> {
         self.instrs
+    }
+
+    fn fresh_temp(&mut self) -> TempId {
+        self.temps.fresh()
     }
 }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,2 +1,3 @@
 pub mod cfg;
+pub mod lower;
 pub mod tac;

--- a/src/ir/tac.rs
+++ b/src/ir/tac.rs
@@ -83,7 +83,7 @@ pub enum TacInstr {
         src: Operand,
     },
     Copy {
-        dst: TempId,
+        dst: Operand,
         src: Operand,
     },
     Jump {


### PR DESCRIPTION
## Resumo

Implementa o lowering da AST para TAC em `src/ir/lower.rs`, adicionando o visitor responsável por transformar expressões, statements, funções e programas em `TacProgram`.

## O que foi feito

- Adiciona `Lowerer { temps, labels, instrs }`.
- Implementa `lower_expr(&Expr) -> Operand` para:
  - literais
  - identificadores
  - expressões binárias
  - expressões unárias
  - chamadas de função
  - casts simples
  - atribuições
  - atribuições compostas
  - `++` / `--`
  - ternário
  - `sizeof(type)` quando o tamanho é conhecido
- Implementa `lower_stmt(&Stmt)` para:
  - blocos
  - declaração de variável com inicializador
  - `if` / `else`
  - `while`
  - `for`
  - `do while`
  - `break`
  - `continue`
  - `return`
  - expression statements
- Implementa:
  - `lower_function`
  - `lower_program`
- Ajusta `TacInstr::Copy` para aceitar `Operand` como destino, permitindo representar corretamente cópias para variáveis, como `x = t0`.
- Adiciona testes unitários cobrindo:
  - expressão binária gerando temporário
  - `if/else` gerando labels
  - `while` gerando backedge
  - chamada de função preservando argumentos
  - expressão aninhada preservando ordem dos temporários
  - lowering de função com nome, parâmetros e corpo

## Observações

Alguns nós da AST que exigem suporte adicional de layout/endereço ainda falham explicitamente em vez de gerar TAC incorreto, como `switch`, acesso por índice, acesso a membro e `sizeof(expr)`.

## Testes

```bash
cargo test
```

Resultado: todos os testes passaram.