### PR TITLE
test(integration): suíte de testes end-to-end com programas C reais

### DIFF
--- a/tests/integration/invalid/arity_mismatch.c
+++ b/tests/integration/invalid/arity_mismatch.c
@@ -1,0 +1,7 @@
+int add(int a, int b) {
+    return a + b;
+}
+
+int main(void) {
+    return add(1);
+}

--- a/tests/integration/invalid/assign_const.c
+++ b/tests/integration/invalid/assign_const.c
@@ -1,0 +1,5 @@
+int main(void) {
+    const int PI = 3;
+    PI = 4;
+    return PI;
+}

--- a/tests/integration/invalid/call_non_function.c
+++ b/tests/integration/invalid/call_non_function.c
@@ -1,0 +1,8 @@
+void f(void) {
+    int x = 1;
+    x();
+}
+
+int main(void) {
+    return 0;
+}

--- a/tests/integration/invalid/redeclaration.c
+++ b/tests/integration/invalid/redeclaration.c
@@ -1,0 +1,5 @@
+int main(void) {
+    int x = 1;
+    int x = 2;
+    return x;
+}

--- a/tests/integration/invalid/return_in_void.c
+++ b/tests/integration/invalid/return_in_void.c
@@ -1,0 +1,7 @@
+void f(void) {
+    return 1;
+}
+
+int main(void) {
+    return 0;
+}

--- a/tests/integration/invalid/type_mismatch_assign.c
+++ b/tests/integration/invalid/type_mismatch_assign.c
@@ -1,0 +1,5 @@
+int main(void) {
+    int x;
+    x = "hello";
+    return x;
+}

--- a/tests/integration/invalid/undeclared_var.c
+++ b/tests/integration/invalid/undeclared_var.c
@@ -1,0 +1,4 @@
+int main(void) {
+    int y = x;
+    return y;
+}

--- a/tests/integration/valid/arithmetic.c
+++ b/tests/integration/valid/arithmetic.c
@@ -1,0 +1,10 @@
+int main(void) {
+    int a = 10;
+    int b = 3;
+    int sum = a + b;
+    int diff = a - b;
+    int prod = a * b;
+    int quot = a / b;
+    int rem = a % b;
+    return sum + diff + prod + quot + rem;
+}

--- a/tests/integration/valid/control_flow.c
+++ b/tests/integration/valid/control_flow.c
@@ -1,0 +1,30 @@
+int classify(int n) {
+    int result = 0;
+    switch (n) {
+        case 1:
+            result = 1;
+            break;
+        case 2:
+            result = 2;
+            break;
+        default:
+            result = -1;
+            break;
+    }
+    return result;
+}
+
+int main(void) {
+    int total = 0;
+    for (int i = 0; i < 3; i = i + 1) {
+        total = total + classify(i);
+    }
+    while (total > 0) {
+        total = total - 1;
+    }
+    if (total == 0) {
+        return 0;
+    } else {
+        return 1;
+    }
+}

--- a/tests/integration/valid/enum_usage.c
+++ b/tests/integration/valid/enum_usage.c
@@ -1,0 +1,13 @@
+enum Color {
+    RED,
+    GREEN,
+    BLUE
+};
+
+int main(void) {
+    int c = GREEN;
+    if (c == RED) {
+        return c;
+    }
+    return BLUE;
+}

--- a/tests/integration/valid/fibonacci.c
+++ b/tests/integration/valid/fibonacci.c
@@ -1,0 +1,10 @@
+int fib(int n) {
+    if (n <= 1) {
+        return n;
+    }
+    return fib(n - 1) + fib(n - 2);
+}
+
+int main(void) {
+    return fib(10);
+}

--- a/tests/integration/valid/hello_world.c
+++ b/tests/integration/valid/hello_world.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/tests/integration/valid/pointers.c
+++ b/tests/integration/valid/pointers.c
@@ -1,0 +1,10 @@
+int main(void) {
+    int x = 5;
+    int *p = &x;
+    int *q = p;
+    p[0] = x + 1;
+    int offset = 1;
+    int *r = q + offset;
+    int v = r[0];
+    return v + p[0] + offset;
+}

--- a/tests/integration/valid/structs.c
+++ b/tests/integration/valid/structs.c
@@ -1,0 +1,13 @@
+struct Point {
+    int x;
+    int y;
+};
+
+struct Point origin;
+
+int main(void) {
+    origin.x = 0;
+    origin.y = 0;
+    origin.x = origin.x + 1;
+    return origin.x + origin.y;
+}

--- a/tests/integration/valid/typedef.c
+++ b/tests/integration/valid/typedef.c
@@ -1,0 +1,16 @@
+typedef int MyInt;
+
+struct Point {
+    int x;
+    int y;
+};
+
+typedef struct Point Point;
+
+Point origin;
+
+int main(void) {
+    MyInt a = 5;
+    origin.x = a;
+    return origin.x + a;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,160 @@
+use std::path::PathBuf;
+
+use crusty::analyser::analyse;
+use crusty::common::errors::types::{CompilerError, Diagnostic, SemanticErrorKind};
+use crusty::common::input::source::SourceFile;
+use crusty::lexer::scanner::Scanner;
+use crusty::parser::Parser;
+
+struct CompileResult {
+    diagnostics: Vec<Diagnostic>,
+}
+
+fn compile_file(rel: &str) -> CompileResult {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let src = SourceFile::from_path(path)
+        .unwrap_or_else(|e| panic!("failed to read fixture '{rel}': {:?}", e.to_report()));
+
+    let mut scanner = Scanner::new(src);
+    scanner.scan();
+    let lex_diags = std::mem::take(&mut scanner.diagnostics);
+    let tokens = std::mem::take(&mut scanner.tokens);
+
+    let mut diagnostics: Vec<Diagnostic> = lex_diags.into_iter().map(Diagnostic::Error).collect();
+
+    let mut parser = Parser::new(tokens);
+    match parser.parse_program() {
+        Ok(program) => diagnostics.extend(analyse(&program)),
+        Err(parse_errs) => diagnostics.extend(parse_errs.into_iter().map(Diagnostic::Error)),
+    }
+
+    CompileResult { diagnostics }
+}
+
+fn has_semantic_error(diags: &[Diagnostic], pred: impl Fn(&SemanticErrorKind) -> bool) -> bool {
+    diags.iter().any(|d| match d {
+        Diagnostic::Error(CompilerError::Semantic(se)) => pred(&se.kind),
+        _ => false,
+    })
+}
+
+fn compile_valid(name: &str) {
+    let result = compile_file(&format!("tests/integration/valid/{name}.c"));
+    assert!(
+        result.diagnostics.is_empty(),
+        "valid program '{name}' should produce zero diagnostics, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+fn assert_invalid(name: &str, pred: impl Fn(&SemanticErrorKind) -> bool, label: &str) {
+    let result = compile_file(&format!("tests/integration/invalid/{name}.c"));
+    assert!(
+        has_semantic_error(&result.diagnostics, pred),
+        "invalid program '{name}' should emit {label}, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn valid_hello_world() {
+    compile_valid("hello_world");
+}
+
+#[test]
+fn valid_arithmetic() {
+    compile_valid("arithmetic");
+}
+
+#[test]
+fn valid_fibonacci() {
+    compile_valid("fibonacci");
+}
+
+#[test]
+fn valid_structs() {
+    compile_valid("structs");
+}
+
+#[test]
+fn valid_pointers() {
+    compile_valid("pointers");
+}
+
+#[test]
+fn valid_typedef() {
+    compile_valid("typedef");
+}
+
+#[test]
+fn valid_enum_usage() {
+    compile_valid("enum_usage");
+}
+
+#[test]
+fn valid_control_flow() {
+    compile_valid("control_flow");
+}
+
+#[test]
+fn invalid_undeclared_var_emits_error() {
+    assert_invalid(
+        "undeclared_var",
+        |k| matches!(k, SemanticErrorKind::UndefinedVariable(_)),
+        "UndefinedVariable",
+    );
+}
+
+#[test]
+fn invalid_type_mismatch_assign_emits_error() {
+    assert_invalid(
+        "type_mismatch_assign",
+        |k| matches!(k, SemanticErrorKind::TypeMismatch { .. }),
+        "TypeMismatch",
+    );
+}
+
+#[test]
+fn invalid_assign_const_emits_error() {
+    assert_invalid(
+        "assign_const",
+        |k| matches!(k, SemanticErrorKind::AssignToConst(_)),
+        "AssignToConst",
+    );
+}
+
+#[test]
+fn invalid_redeclaration_emits_error() {
+    assert_invalid(
+        "redeclaration",
+        |k| matches!(k, SemanticErrorKind::Redeclaration(_)),
+        "Redeclaration",
+    );
+}
+
+#[test]
+fn invalid_return_in_void_emits_error() {
+    assert_invalid(
+        "return_in_void",
+        |k| matches!(k, SemanticErrorKind::ReturnInVoid),
+        "ReturnInVoid",
+    );
+}
+
+#[test]
+fn invalid_arity_mismatch_emits_error() {
+    assert_invalid(
+        "arity_mismatch",
+        |k| matches!(k, SemanticErrorKind::ArityMismatch { .. }),
+        "ArityMismatch",
+    );
+}
+
+#[test]
+fn invalid_call_non_function_emits_error() {
+    assert_invalid(
+        "call_non_function",
+        |k| matches!(k, SemanticErrorKind::CallNonFunction(_)),
+        "CallNonFunction",
+    );
+}


### PR DESCRIPTION
## Contexto

A suíte de testes atual cobre unitariamente lexer, parser e semântico, mas não há testes que exercitem o pipeline completo de ponta-a-ponta em programas C reais. Este PR adiciona essa suíte de integração.

## O que foi feito

`tests/integration_test.rs` com helper `compile_file()` que executa o pipeline completo (lex → parse → semantic) e coleta diagnósticos de todas as fases, mais **15 testes**:

### Válidos (8) — zero diagnósticos
`hello_world`, `arithmetic`, `fibonacci`, `structs`, `pointers`, `typedef`, `enum_usage`, `control_flow`

### Inválidos (7) — diagnóstico esperado
| Arquivo | `SemanticErrorKind` |
|---|---|
| `undeclared_var` | `UndefinedVariable` |
| `type_mismatch_assign` | `TypeMismatch` |
| `assign_const` | `AssignToConst` |
| `redeclaration` | `Redeclaration` |
| `return_in_void` | `ReturnInVoid` |
| `arity_mismatch` | `ArityMismatch` |
| `call_non_function` | `CallNonFunction` |

## Notas de implementação
- **Sem alterações em `src/`** nem no CI (o workflow já roda `cargo test --all`, que coleta `tests/` automaticamente).
- Programas válidos evitam `printf`/stdlib (o lexer descarta `#include` e não há protótipos variádicos), usam funções próprias e `return`.
- Funções chamadoras são definidas após as chamadas (callee-first) para evitar forward-ref/`PrototypeMissingBody`.
- Toda variável local é inicializada e consumida (sem warnings de `UnusedVariable`/`MayBeUninitialized`), atendendo ao critério de zero diagnósticos.
- Structs usam instâncias globais (não há struct-literal e struct local lida em `p.x =` dispara warning de uninit).

## Critérios de aceite
- [x] 8 programas válidos sem falsos-positivos
- [x] 7 programas inválidos com diagnósticos corretos
- [x] Tudo roda em `cargo test`
- [x] CI verde 