### PR TITLE
perf(parser): eliminate O(n²) clones in postfix chaining (#86)

### DIFF
--- a/docs/parser.md
+++ b/docs/parser.md
@@ -305,7 +305,7 @@ Parseadas por `parse_prefix_expr()` antes do loop Pratt:
 
 ### Postfix Expressions
 
-`try_parse_postfix(lhs)` retorna `true` se consumiu algo:
+`try_parse_postfix(lhs)` retorna `(expr, true)` se consumiu algo (tomando `lhs` por valor e devolvendo o novo nó) ou `(lhs, false)` caso contrário:
 
 | Token | Nó produzido |
 |---|---|

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -52,7 +52,11 @@ impl Parser {
 
         loop {
             // Primeiro tratamos todos os postfix, pois têm maior precedência efetiva.
-            if postfix::try_parse_postfix(self, &mut lhs)? {
+            // `try_parse_postfix` toma `lhs` por valor e devolve o novo nó (ou o mesmo
+            // `lhs` intocado quando não há postfix), evitando clones O(n²) em cadeias.
+            let (next_lhs, consumed) = postfix::try_parse_postfix(self, lhs)?;
+            lhs = next_lhs;
+            if consumed {
                 continue;
             }
 

--- a/src/parser/rules/expressions/postfix.rs
+++ b/src/parser/rules/expressions/postfix.rs
@@ -4,8 +4,13 @@ use crate::lexer::tokens::token_kind::TokenKind;
 use crate::parser::parser::Parser;
 
 /// Tenta parsear uma operação postfix (`()`, `[]`, `.`, `->`, `++`, `--`) sobre `lhs`.
-/// Retorna `Ok(true)` se consumiu um postfix, `Ok(false)` se não há postfix aplicável.
-pub fn try_parse_postfix(parser: &mut Parser, lhs: &mut Expr) -> Result<bool, CompilerError> {
+///
+/// Recebe `lhs` **por valor** para encapsulá-lo em um novo nó movendo (e não clonando)
+/// a subexpressão. Encadeamentos como `a.b.c.d.e.f` assim crescem em O(n) em vez de O(n²).
+///
+/// Retorna `Ok((expr, true))` se consumiu um postfix (com o novo nó já construído) ou
+/// `Ok((lhs, false))` quando não há postfix aplicável (devolvendo `lhs` intacto).
+pub fn try_parse_postfix(parser: &mut Parser, lhs: Expr) -> Result<(Expr, bool), CompilerError> {
     match parser.peek_kind() {
         TokenKind::LeftParen => {
             let start = lhs.span();
@@ -25,8 +30,8 @@ pub fn try_parse_postfix(parser: &mut Parser, lhs: &mut Expr) -> Result<bool, Co
                 .expect(&TokenKind::RightParen, "')' ao fechar chamada")?
                 .clone();
             let span = parser.join_span(start, parser.span_of(&end));
-            *lhs = Expr::Call(Box::new(lhs.clone()), args, span);
-            Ok(true)
+            let new_expr = Expr::Call(Box::new(lhs), args, span);
+            Ok((new_expr, true))
         }
         TokenKind::LeftBracket => {
             let start = lhs.span();
@@ -36,10 +41,11 @@ pub fn try_parse_postfix(parser: &mut Parser, lhs: &mut Expr) -> Result<bool, Co
                 .expect(&TokenKind::RightBracket, "']' ao fechar indexação")?
                 .clone();
             let span = parser.join_span(start, parser.span_of(&end));
-            *lhs = Expr::Index(Box::new(lhs.clone()), Box::new(index), span);
-            Ok(true)
+            let new_expr = Expr::Index(Box::new(lhs), Box::new(index), span);
+            Ok((new_expr, true))
         }
         TokenKind::Dot | TokenKind::Arrow => {
+            let start = lhs.span();
             let op = parser.advance().clone();
             let field_token = parser.advance().clone();
             let TokenKind::Identifier(field_name) = field_token.kind.clone() else {
@@ -50,26 +56,27 @@ pub fn try_parse_postfix(parser: &mut Parser, lhs: &mut Expr) -> Result<bool, Co
                 ));
             };
 
-            let span = parser.join_span(lhs.span(), parser.span_of(&field_token));
+            let span = parser.join_span(start, parser.span_of(&field_token));
             let access = if op.kind == TokenKind::Dot {
                 MemberAccess::Direct
             } else {
                 MemberAccess::Pointer
             };
-            *lhs = Expr::Member(Box::new(lhs.clone()), access, field_name, span);
-            Ok(true)
+            let new_expr = Expr::Member(Box::new(lhs), access, field_name, span);
+            Ok((new_expr, true))
         }
         TokenKind::PlusPlus | TokenKind::MinusMinus => {
+            let start = lhs.span();
             let op = parser.advance().clone();
-            let span = parser.join_span(lhs.span(), parser.span_of(&op));
+            let span = parser.join_span(start, parser.span_of(&op));
             let kind = if op.kind == TokenKind::PlusPlus {
                 PostfixOp::Inc
             } else {
                 PostfixOp::Dec
             };
-            *lhs = Expr::Postfix(kind, Box::new(lhs.clone()), span);
-            Ok(true)
+            let new_expr = Expr::Postfix(kind, Box::new(lhs), span);
+            Ok((new_expr, true))
         }
-        _ => Ok(false),
+        _ => Ok((lhs, false)),
     }
 }

--- a/src/tests/parser_test.rs
+++ b/src/tests/parser_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::common::ast::ast::{QualifierType, Type};
     use crate::common::ast::decl::Decl;
-    use crate::common::ast::expr::{BinOp, Expr, Literal, PostfixOp, PrefixOp};
+    use crate::common::ast::expr::{BinOp, Expr, Literal, MemberAccess, PostfixOp, PrefixOp};
     use crate::common::ast::stmt::{Stmt, SwitchLabel};
     use crate::common::input::span::ByteSpan;
     use crate::lexer::tokens::token::Token;
@@ -138,6 +138,46 @@ mod tests {
             panic!("esperava chamada de função");
         };
         assert_eq!(args.len(), 2);
+    }
+
+    #[test]
+    fn parses_deep_member_access_chain_left_associative() {
+        // a.b.c.d deve produzir Member(Member(Member(a, b), c), d),
+        // encadeamento left-assoc que cresce em O(n) (regressão do issue #86).
+        let tokens = vec![
+            ident("a", 1),
+            tk(TokenKind::Dot, 2),
+            ident("b", 3),
+            tk(TokenKind::Dot, 4),
+            ident("c", 5),
+            tk(TokenKind::Dot, 6),
+            ident("d", 7),
+            eof(8),
+        ];
+
+        let expr = Parser::new(tokens)
+            .parse_expr(0)
+            .expect("encadeamento de membros válido");
+
+        let Expr::Member(inner, MemberAccess::Direct, field, _) = expr else {
+            panic!("esperava Member no topo do encadeamento");
+        };
+        assert_eq!(field, "d");
+
+        let Expr::Member(inner, MemberAccess::Direct, field, _) = *inner else {
+            panic!("esperava Member intermediário");
+        };
+        assert_eq!(field, "c");
+
+        let Expr::Member(inner, MemberAccess::Direct, field, _) = *inner else {
+            panic!("esperava Member intermediário");
+        };
+        assert_eq!(field, "b");
+
+        assert!(matches!(*inner, Expr::Ident(..)));
+        if let Expr::Ident(name, _) = *inner {
+            assert_eq!(name, "a");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Contexto

Issue #86: em `postfix.rs`, cada operador postfix clonava a expressão `lhs` inteira para encapsulá-la em um novo nó. Para uma cadeia como `a.b.c.d.e.f` o custo de cópia era `1 + 2 + 3 + 4 + 5 = O(n²)` em número de operadores.

## Causa raiz

A assinatura `try_parse_postfix(parser, lhs: &mut Expr)` recebia `lhs` por referência mutável, e mover de `&mut T` direto para `Box` não é possível em Rust — daí o `lhs.clone()`.

## Correção

Adotada a **segunda opção** da issue: mudar a assinatura para receber/devolver `Expr` **por valor**:

\`\`\`rust
pub fn try_parse_postfix(parser: &mut Parser, lhs: Expr) -> Result<(Expr, bool), CompilerError>
\`\`\`

Agora `lhs` é movido para dentro do novo nó (`Box::new(lhs)`) em vez de clonado. O único call site (`parser.rs`) foi atualizado para `let (next_lhs, consumed) = postfix::try_parse_postfix(self, lhs)?;`. Cadeias postfix passam a crescer em **O(n)**.

Os 4 clones de `lhs` em `Call`, `Index`, `Member` e `Postfix` foram eliminados.

## Observação

Esta branch (`perf/issue86-postfix-by-value`) já continha o commit `perf(parser): elimina clones O(n^2)` de trabalho anterior que nunca havia sido PRado. Aqui ele foi **rebasado sobre o `developer` atual** (10 commits de IR/lowering à frente) e complementado com um teste de regressão.

## Verificação

- 218 testes passando (215 unit + 3 CLI).
- `cargo fmt --check` limpo.
- `cargo clippy`: sem issues no código alterado.
- Adicionado `parses_deep_member_access_chain_left_associative`, que faz parse de `a.b.c.d` e verifica o formato encaixado `Member(Member(Member(a, b), c), d)` — trava o comportamento left-assoc do encadeamento.

Closes #86.