### PR TITLE
[FIX-159] Remover panics do lowering e do backend

### DIFF
--- a/src/codegen/last/x86_64.rs
+++ b/src/codegen/last/x86_64.rs
@@ -17,7 +17,10 @@
 use crate::codegen::last::abi;
 use crate::codegen::last::frame::{Frame, SlotKey};
 use crate::common::ast::expr::{BinOp, UnOp};
+use crate::common::errors::types::CodegenError;
 use crate::ir::tac::{ConstValue, LabelId, Operand, TacFunction, TacInstr, TacProgram};
+
+type EmitResult<T> = Result<T, CodegenError>;
 
 /// Acumulador de linhas de assembly com indentacao controlada.
 struct Emitter {
@@ -63,23 +66,23 @@ impl Emitter {
 
 /// Emite o assembly de um programa TAC completo, prefixando a diretiva de
 /// secao `.text`.
-pub fn emit_program(prog: &TacProgram) -> String {
+pub fn emit_program(prog: &TacProgram) -> EmitResult<String> {
     let mut em = Emitter::new();
     em.raw(".text");
     for func in &prog.functions {
         em.blank();
-        em.append_str(&emit_function(func));
+        em.append_str(&emit_function(func)?);
     }
     // Marca a stack como nao-executavel (boa pratica; evita aviso do linker e
     // e o que o proprio GCC adiciona a saida assembly).
     em.blank();
     em.raw(".section .note.GNU-stack,\"\",@progbits");
-    em.into_string()
+    Ok(em.into_string())
 }
 
 /// Emite o assembly de uma unica funcao: directiva `.globl`, rotulo,
 /// prologue, corpo e epilogue.
-pub fn emit_function(func: &TacFunction) -> String {
+pub fn emit_function(func: &TacFunction) -> EmitResult<String> {
     let mut em = Emitter::new();
     em.comment(&format!("function {}", func.name));
     em.raw(&format!(".globl {}", func.name));
@@ -108,7 +111,7 @@ pub fn emit_function(func: &TacFunction) -> String {
     // Corpo
     let epilogue_label = format!(".L_{}_epilogue", func.name);
     for instr in &func.instrs {
-        emit_instr(&mut em, instr, &frame, &func.name, &epilogue_label);
+        emit_instr(&mut em, instr, &frame, &func.name, &epilogue_label)?;
     }
 
     // Epilogue (alvo de todos os `return`). Caso a funcao nao tenha `return`
@@ -118,7 +121,7 @@ pub fn emit_function(func: &TacFunction) -> String {
     em.insn("popq %rbp");
     em.insn("ret");
 
-    em.into_string()
+    Ok(em.into_string())
 }
 
 /// Constroi o stack frame pre-escaneando todas as instrucoes para alocar um
@@ -204,40 +207,41 @@ fn emit_instr(
     frame: &Frame,
     func_name: &str,
     epilogue_label: &str,
-) {
+) -> EmitResult<()> {
     match instr {
         TacInstr::Label(label) => {
             em.raw(&format!("{}:", local_label(func_name, label)));
+            Ok(())
         }
         TacInstr::Jump { label } => {
             em.insn(&format!("jmp {}", local_label(func_name, label)));
+            Ok(())
         }
         TacInstr::CondJump {
             cond,
             then_label,
             else_label,
         } => {
-            load_op(em, frame, cond, "rax");
+            load_op(em, frame, cond, "rax")?;
             em.insn("testq %rax, %rax");
             em.insn(&format!("jne {}", local_label(func_name, then_label)));
             em.insn(&format!("jmp {}", local_label(func_name, else_label)));
+            Ok(())
         }
         TacInstr::Copy { dst, src } => {
-            load_op(em, frame, src, "rax");
-            store_op(em, frame, dst, "rax");
+            load_op(em, frame, src, "rax")?;
+            store_op(em, frame, dst, "rax")?;
+            Ok(())
         }
-        TacInstr::BinOp { dst, op, lhs, rhs } => {
-            emit_binop(em, op, lhs, rhs, *dst, frame);
-        }
-        TacInstr::UnOp { dst, op, src } => {
-            emit_unop(em, op, src, *dst, frame);
-        }
+        TacInstr::BinOp { dst, op, lhs, rhs } => emit_binop(em, op, lhs, rhs, *dst, frame),
+        TacInstr::UnOp { dst, op, src } => emit_unop(em, op, src, *dst, frame),
         TacInstr::Call { dst, fn_name, args } => emit_call(em, fn_name, args, *dst, frame),
         TacInstr::Return { val } => {
             if let Some(val) = val {
-                load_op(em, frame, val, "rax");
+                load_op(em, frame, val, "rax")?;
             }
             em.insn(&format!("jmp {epilogue_label}"));
+            Ok(())
         }
     }
 }
@@ -249,16 +253,16 @@ fn emit_binop(
     rhs: &Operand,
     dst: crate::ir::tac::TempId,
     frame: &Frame,
-) {
+) -> EmitResult<()> {
     // Operacoes logicas short-circuit-like precisam normalizar cada operando
     // para 0/1 individualmente.
     if matches!(op, BinOp::And | BinOp::Or) {
-        emit_logical(em, matches!(op, BinOp::Or), lhs, rhs, dst, frame);
-        return;
+        emit_logical(em, matches!(op, BinOp::Or), lhs, rhs, dst, frame)?;
+        return Ok(());
     }
 
-    load_op(em, frame, lhs, "rax");
-    load_op(em, frame, rhs, "rcx");
+    load_op(em, frame, lhs, "rax")?;
+    load_op(em, frame, rhs, "rcx")?;
 
     match op {
         BinOp::Add => em.insn("addq %rcx, %rax"),
@@ -284,10 +288,16 @@ fn emit_binop(
         BinOp::Geq => emit_comparison(em, "setge"),
         BinOp::Eq => emit_comparison(em, "sete"),
         BinOp::Neq => emit_comparison(em, "setne"),
-        BinOp::And | BinOp::Or => unreachable!("tratado em emit_logical"),
+        BinOp::And | BinOp::Or => {
+            return Err(codegen_error(
+                "operacao logica deveria ter sido tratada antes",
+                Some("binop"),
+            ))
+        }
     }
 
-    store_op(em, frame, &Operand::Temp(dst), "rax");
+    store_op(em, frame, &Operand::Temp(dst), "rax")?;
+    Ok(())
 }
 
 fn emit_comparison(em: &mut Emitter, setcc: &str) {
@@ -303,16 +313,16 @@ fn emit_logical(
     rhs: &Operand,
     dst: crate::ir::tac::TempId,
     frame: &Frame,
-) {
+) -> EmitResult<()> {
     // Normaliza lhs para 0/1 em %rdx.
-    load_op(em, frame, lhs, "rax");
+    load_op(em, frame, lhs, "rax")?;
     em.insn("testq %rax, %rax");
     em.insn("setne %al");
     em.insn("movzbq %al, %rax");
     em.insn("movq %rax, %rdx");
 
     // Normaliza rhs para 0/1 em %rax.
-    load_op(em, frame, rhs, "rax");
+    load_op(em, frame, rhs, "rax")?;
     em.insn("testq %rax, %rax");
     em.insn("setne %al");
     em.insn("movzbq %al, %rax");
@@ -323,7 +333,8 @@ fn emit_logical(
         em.insn("andq %rdx, %rax");
     }
 
-    store_op(em, frame, &Operand::Temp(dst), "rax");
+    store_op(em, frame, &Operand::Temp(dst), "rax")?;
+    Ok(())
 }
 
 fn emit_unop(
@@ -332,8 +343,8 @@ fn emit_unop(
     src: &Operand,
     dst: crate::ir::tac::TempId,
     frame: &Frame,
-) {
-    load_op(em, frame, src, "rax");
+) -> EmitResult<()> {
+    load_op(em, frame, src, "rax")?;
     match op {
         UnOp::Neg => em.insn("negq %rax"),
         UnOp::BitNot => em.insn("notq %rax"),
@@ -342,10 +353,21 @@ fn emit_unop(
             em.insn("sete %al");
             em.insn("movzbq %al, %rax");
         }
-        UnOp::Deref => panic!("codegen de deref (*) nao suportado neste backend"),
-        UnOp::AddrOf => panic!("codegen de address-of (&) nao suportado neste backend"),
+        UnOp::Deref => {
+            return Err(codegen_error(
+                "codegen de deref (*) nao suportado neste backend",
+                Some("unop"),
+            ))
+        }
+        UnOp::AddrOf => {
+            return Err(codegen_error(
+                "codegen de address-of (&) nao suportado neste backend",
+                Some("unop"),
+            ))
+        }
     }
-    store_op(em, frame, &Operand::Temp(dst), "rax");
+    store_op(em, frame, &Operand::Temp(dst), "rax")?;
+    Ok(())
 }
 
 fn emit_call(
@@ -354,7 +376,7 @@ fn emit_call(
     args: &[Operand],
     dst: Option<crate::ir::tac::TempId>,
     frame: &Frame,
-) {
+) -> EmitResult<()> {
     // Argumentos alem de `MAX_REG_ARGS` vao para a stack do chamador, na
     // ordem inversa (o primeiro arg de stack fica no topo, mais proximo do
     // endereco de retorno), espelhando `abi::stack_arg_offset`.
@@ -367,13 +389,13 @@ fn emit_call(
     }
     let stack_args = &args[args.len().min(abi::MAX_REG_ARGS)..];
     for arg in stack_args.iter().rev() {
-        load_op(em, frame, arg, "rax");
+        load_op(em, frame, arg, "rax")?;
         em.insn("pushq %rax");
     }
 
     for (index, arg) in args.iter().take(abi::MAX_REG_ARGS).enumerate() {
         let reg = abi::arg_register(index).expect("index < MAX_REG_ARGS sempre tem registrador");
-        load_op(em, frame, arg, "rax");
+        load_op(em, frame, arg, "rax")?;
         em.insn(&format!("movq %rax, %{reg}"));
     }
 
@@ -385,31 +407,37 @@ fn emit_call(
     }
 
     if let Some(dst) = dst {
-        store_op(em, frame, &Operand::Temp(dst), "rax");
+        store_op(em, frame, &Operand::Temp(dst), "rax")?;
     }
+    Ok(())
 }
 
 /// Carrega `op` para o registrador nomeado (ex.: "rax", "rcx").
-fn load_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str) {
+fn load_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str) -> EmitResult<()> {
     match op {
-        Operand::Const(value) => em.insn(&format!("movq ${}, %{reg}", const_immediate(value))),
+        Operand::Const(value) => {
+            em.insn(&format!("movq ${}, %{reg}", const_immediate(value)?));
+            Ok(())
+        }
         Operand::Temp(temp) => {
             let offset = frame
                 .offset_of(&SlotKey::Temp(temp.0))
                 .expect("temp sem slot alocado");
             em.insn(&format!("movq {offset}(%rbp), %{reg}"));
+            Ok(())
         }
         Operand::Var(name) => {
             let offset = frame
                 .offset_of(&SlotKey::Var(name.clone()))
                 .expect("var sem slot alocado");
             em.insn(&format!("movq {offset}(%rbp), %{reg}"));
+            Ok(())
         }
     }
 }
 
 /// Armazena o registrador nomeado em `op` (que deve ser temp ou var).
-fn store_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str) {
+fn store_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str) -> EmitResult<()> {
     let offset = match op {
         Operand::Temp(temp) => frame
             .offset_of(&SlotKey::Temp(temp.0))
@@ -417,17 +445,36 @@ fn store_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str) {
         Operand::Var(name) => frame
             .offset_of(&SlotKey::Var(name.clone()))
             .expect("var sem slot alocado"),
-        Operand::Const(_) => panic!("nao e possivel armazenar em uma constante"),
+        Operand::Const(_) => {
+            return Err(codegen_error(
+                "nao e possivel armazenar em uma constante",
+                Some("store"),
+            ))
+        }
     };
     em.insn(&format!("movq %{reg}, {offset}(%rbp)"));
+    Ok(())
 }
 
-fn const_immediate(value: &ConstValue) -> String {
+fn const_immediate(value: &ConstValue) -> EmitResult<String> {
     match value {
-        ConstValue::Int(v) => v.to_string(),
-        ConstValue::Char(c) => (*c as i64).to_string(),
-        ConstValue::Double(_) => panic!("codegen de double nao suportado neste backend"),
-        ConstValue::String(_) => panic!("codegen de string literal nao suportado neste backend"),
+        ConstValue::Int(v) => Ok(v.to_string()),
+        ConstValue::Char(c) => Ok((*c as i64).to_string()),
+        ConstValue::Double(_) => Err(codegen_error(
+            "codegen de double nao suportado neste backend",
+            Some("const"),
+        )),
+        ConstValue::String(_) => Err(codegen_error(
+            "codegen de string literal nao suportado neste backend",
+            Some("const"),
+        )),
+    }
+}
+
+fn codegen_error(message: &str, instruction: Option<&str>) -> CodegenError {
+    CodegenError {
+        message: message.to_string(),
+        instruction: instruction.map(str::to_string),
     }
 }
 
@@ -460,7 +507,7 @@ mod tests {
 
     #[test]
     fn emit_function_prologue_pushes_rbp_and_sets_frame() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const()).unwrap();
 
         assert!(out.contains("pushq %rbp"));
         assert!(out.contains("movq %rsp, %rbp"));
@@ -469,7 +516,7 @@ mod tests {
 
     #[test]
     fn emit_function_declares_global_symbol() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const()).unwrap();
 
         assert!(out.contains(".globl main"));
         assert!(out.contains("main:\n"));
@@ -477,7 +524,7 @@ mod tests {
 
     #[test]
     fn return_const_loads_immediate_into_rax() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const()).unwrap();
 
         assert!(out.contains("movq $42, %rax"));
     }
@@ -500,7 +547,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("movq %rdi, -8(%rbp)")); // spill arg a
         assert!(out.contains("movq %rsi, -16(%rbp)")); // spill arg b
@@ -525,7 +572,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("cqto"));
         assert!(out.contains("idivq %rcx"));
@@ -544,7 +591,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("movq %rdx, %rax"));
     }
@@ -562,7 +609,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("cmpq %rcx, %rax"));
         assert!(out.contains("setl %al"));
@@ -589,7 +636,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("movq %rax, %rdi"));
         assert!(out.contains("movq %rax, %rsi"));
@@ -616,10 +663,8 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
-        // 7th arg (index 6) e o unico passado pela stack; aligna a stack com
-        // 8 bytes de padding (1 arg de stack e impar) antes do push.
         assert!(out.contains("subq $8, %rsp"));
         assert!(out.contains("pushq %rax"));
         assert!(out.contains("call sum7"));
@@ -641,9 +686,8 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
-        // 2 args de stack (indices 6 e 7): par, sem padding necessario.
         assert!(!out.contains("subq $8, %rsp"));
         assert!(out.contains("addq $16, %rsp"));
     }
@@ -661,7 +705,8 @@ mod tests {
                     Operand::Const(ConstValue::Int(2)),
                 ],
             }],
-        ));
+        ))
+        .unwrap();
 
         assert!(!out.contains("pushq %rax"));
         assert!(!out.contains("addq $16, %rsp"));
@@ -689,7 +734,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("testq %rax, %rax"));
         assert!(out.contains("jne .L_cond_L0"));
@@ -700,7 +745,7 @@ mod tests {
 
     #[test]
     fn epilogue_label_is_emitted_once() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const()).unwrap();
 
         assert_eq!(out.matches(".L_main_epilogue:").count(), 1);
     }
@@ -711,7 +756,7 @@ mod tests {
             functions: vec![asm_simple_return_const()],
         };
 
-        let out = emit_program(&prog);
+        let out = emit_program(&prog).unwrap();
 
         assert!(out.starts_with(".text"));
         assert!(out.contains(".globl main"));
@@ -730,7 +775,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("setne %al"));
         assert!(out.contains("andq %rdx, %rax"));
@@ -749,7 +794,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f).unwrap();
 
         assert!(out.contains("orq %rdx, %rax"));
     }

--- a/src/examples/simple.c
+++ b/src/examples/simple.c
@@ -1,0 +1,4 @@
+
+int main() {
+    return 42;
+}

--- a/src/ir/lower.rs
+++ b/src/ir/lower.rs
@@ -4,9 +4,12 @@ use crate::common::ast::{
     expr::{BinOp, Expr, Literal, PostfixOp, PrefixOp},
     stmt::Stmt,
 };
+use crate::common::errors::types::CodegenError;
 use crate::ir::tac::{
     ConstValue, LabelGen, LabelId, Operand, TacFunction, TacInstr, TacProgram, TempGen, TempId,
 };
+
+type LowerResult<T> = Result<T, CodegenError>;
 
 #[derive(Debug, Clone)]
 pub struct Lowerer {
@@ -30,13 +33,13 @@ impl Lowerer {
         }
     }
 
-    pub fn lower_expr(&mut self, expr: &Expr) -> Operand {
+    pub fn lower_expr(&mut self, expr: &Expr) -> LowerResult<Operand> {
         match expr {
-            Expr::Literal(value, _) => Operand::Const(lower_literal(value)),
-            Expr::Ident(name, _) => Operand::Var(name.clone()),
+            Expr::Literal(value, _) => Ok(Operand::Const(lower_literal(value))),
+            Expr::Ident(name, _) => Ok(Operand::Var(name.clone())),
             Expr::Binary(lhs, op, rhs, _) => {
-                let lhs = self.lower_expr(lhs);
-                let rhs = self.lower_expr(rhs);
+                let lhs = self.lower_expr(lhs)?;
+                let rhs = self.lower_expr(rhs)?;
                 let dst = self.fresh_temp();
                 self.instrs.push(TacInstr::BinOp {
                     dst,
@@ -44,44 +47,52 @@ impl Lowerer {
                     lhs,
                     rhs,
                 });
-                Operand::Temp(dst)
+                Ok(Operand::Temp(dst))
             }
             Expr::Unary(op, src, _) => {
-                let src = self.lower_expr(src);
+                let src = self.lower_expr(src)?;
                 let dst = self.fresh_temp();
                 self.instrs.push(TacInstr::UnOp {
                     dst,
                     op: op.clone(),
                     src,
                 });
-                Operand::Temp(dst)
+                Ok(Operand::Temp(dst))
             }
             Expr::Prefix(op, target, _) => self.lower_prefix(op, target),
             Expr::Postfix(op, target, _) => self.lower_postfix(op, target),
             Expr::Call(callee, args, _) => {
                 let fn_name = match callee.as_ref() {
                     Expr::Ident(name, _) => name.clone(),
-                    _ => panic!("lowering ainda nao suporta chamada por expressao"),
+                    _ => {
+                        return Err(codegen_error(
+                            "chamada por expressao nao suportada no lowering",
+                            Some("call"),
+                        ));
+                    }
                 };
-                let args = args.iter().map(|arg| self.lower_expr(arg)).collect();
+                let mut lowered_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    lowered_args.push(self.lower_expr(arg)?);
+                }
                 let dst = self.fresh_temp();
                 self.instrs.push(TacInstr::Call {
                     dst: Some(dst),
                     fn_name,
-                    args,
+                    args: lowered_args,
                 });
-                Operand::Temp(dst)
+                Ok(Operand::Temp(dst))
             }
             Expr::Cast(_, inner, _) => self.lower_expr(inner),
             Expr::Assign(lhs, rhs, _) => {
-                let src = self.lower_expr(rhs);
-                let dst = self.lower_assignment_target(lhs);
-                self.emit_copy(dst.clone(), src);
-                dst
+                let src = self.lower_expr(rhs)?;
+                let dst = self.lower_assignment_target(lhs)?;
+                self.emit_copy(dst.clone(), src)?;
+                Ok(dst)
             }
             Expr::CompoundAssign(op, lhs, rhs, _) => {
-                let dst = self.lower_assignment_target(lhs);
-                let rhs = self.lower_expr(rhs);
+                let dst = self.lower_assignment_target(lhs)?;
+                let rhs = self.lower_expr(rhs)?;
                 let temp = self.fresh_temp();
                 self.instrs.push(TacInstr::BinOp {
                     dst: temp,
@@ -89,12 +100,12 @@ impl Lowerer {
                     lhs: dst.clone(),
                     rhs,
                 });
-                self.emit_copy(dst.clone(), Operand::Temp(temp));
-                dst
+                self.emit_copy(dst.clone(), Operand::Temp(temp))?;
+                Ok(dst)
             }
-            Expr::SizeofType(qty, _) => Operand::Const(ConstValue::Int(type_size(&qty.ty))),
+            Expr::SizeofType(qty, _) => Ok(Operand::Const(ConstValue::Int(type_size(&qty.ty)?))),
             Expr::Ternary(cond, then_expr, else_expr, _) => {
-                let cond = self.lower_expr(cond);
+                let cond = self.lower_expr(cond)?;
                 let then_label = self.labels.fresh();
                 let else_label = self.labels.fresh();
                 let end_label = self.labels.fresh();
@@ -107,36 +118,46 @@ impl Lowerer {
                 });
 
                 self.instrs.push(TacInstr::Label(then_label));
-                let then_val = self.lower_expr(then_expr);
-                self.emit_copy(Operand::Temp(dst), then_val);
+                let then_val = self.lower_expr(then_expr)?;
+                self.emit_copy(Operand::Temp(dst), then_val)?;
                 self.emit_jump_unless_terminated(end_label);
 
                 self.instrs.push(TacInstr::Label(else_label));
-                let else_val = self.lower_expr(else_expr);
-                self.emit_copy(Operand::Temp(dst), else_val);
+                let else_val = self.lower_expr(else_expr)?;
+                self.emit_copy(Operand::Temp(dst), else_val)?;
 
                 self.instrs.push(TacInstr::Label(end_label));
-                Operand::Temp(dst)
+                Ok(Operand::Temp(dst))
             }
-            Expr::Index(_, _, _) => panic!("lowering ainda nao suporta acesso por indice"),
-            Expr::Member(_, _, _, _) => panic!("lowering ainda nao suporta acesso a membro"),
-            Expr::Sizeof(_, _) => panic!("lowering de sizeof(expr) requer informacao de tipo"),
+            Expr::Index(_, _, _) => Err(codegen_error(
+                "acesso por indice nao suportado no lowering",
+                Some("index"),
+            )),
+            Expr::Member(_, _, _, _) => Err(codegen_error(
+                "acesso a membro nao suportado no lowering",
+                Some("member"),
+            )),
+            Expr::Sizeof(_, _) => Err(codegen_error(
+                "sizeof(expr) nao suportado no lowering sem informacao de tipo",
+                Some("sizeof"),
+            )),
         }
     }
 
-    pub fn lower_stmt(&mut self, stmt: &Stmt) {
-        self.lower_stmt_with_control(stmt, ControlLabels::default());
+    pub fn lower_stmt(&mut self, stmt: &Stmt) -> LowerResult<()> {
+        self.lower_stmt_with_control(stmt, ControlLabels::default())
     }
 
-    fn lower_stmt_with_control(&mut self, stmt: &Stmt, control: ControlLabels) {
+    fn lower_stmt_with_control(&mut self, stmt: &Stmt, control: ControlLabels) -> LowerResult<()> {
         match stmt {
             Stmt::Block(stmts, _) => {
                 for stmt in stmts {
-                    self.lower_stmt_with_control(stmt, control);
+                    self.lower_stmt_with_control(stmt, control)?;
                 }
+                Ok(())
             }
             Stmt::If(cond, then_branch, else_branch, _) => {
-                let cond = self.lower_expr(cond);
+                let cond = self.lower_expr(cond)?;
                 let then_label = self.labels.fresh();
                 let else_label = self.labels.fresh();
                 let end_label = self.labels.fresh();
@@ -148,14 +169,15 @@ impl Lowerer {
                 });
 
                 self.instrs.push(TacInstr::Label(then_label));
-                self.lower_stmt_with_control(then_branch, control);
+                self.lower_stmt_with_control(then_branch, control)?;
                 self.emit_jump_unless_terminated(end_label);
 
                 self.instrs.push(TacInstr::Label(else_label));
                 if let Some(else_branch) = else_branch {
-                    self.lower_stmt_with_control(else_branch, control);
+                    self.lower_stmt_with_control(else_branch, control)?;
                 }
                 self.instrs.push(TacInstr::Label(end_label));
+                Ok(())
             }
             Stmt::While(cond, body, _) => {
                 let cond_label = self.labels.fresh();
@@ -163,7 +185,7 @@ impl Lowerer {
                 let end_label = self.labels.fresh();
 
                 self.instrs.push(TacInstr::Label(cond_label));
-                let cond = self.lower_expr(cond);
+                let cond = self.lower_expr(cond)?;
                 self.instrs.push(TacInstr::CondJump {
                     cond,
                     then_label: body_label,
@@ -177,14 +199,15 @@ impl Lowerer {
                         break_label: Some(end_label),
                         continue_label: Some(cond_label),
                     },
-                );
+                )?;
                 self.emit_jump_unless_terminated(cond_label);
 
                 self.instrs.push(TacInstr::Label(end_label));
+                Ok(())
             }
             Stmt::For(init, cond, inc, body, _) => {
                 if let Some(init) = init {
-                    self.lower_stmt_with_control(init, control);
+                    self.lower_stmt_with_control(init, control)?;
                 }
 
                 let cond_label = self.labels.fresh();
@@ -195,7 +218,7 @@ impl Lowerer {
 
                 self.instrs.push(TacInstr::Label(cond_label));
                 if let Some(cond) = cond {
-                    let cond = self.lower_expr(cond);
+                    let cond = self.lower_expr(cond)?;
                     self.instrs.push(TacInstr::CondJump {
                         cond,
                         then_label: body_label,
@@ -210,17 +233,18 @@ impl Lowerer {
                         break_label: Some(end_label),
                         continue_label: Some(continue_label),
                     },
-                );
+                )?;
 
                 if let Some(inc_label) = inc_label {
                     self.instrs.push(TacInstr::Label(inc_label));
                     if let Some(inc) = inc {
-                        self.lower_expr(inc);
+                        self.lower_expr(inc)?;
                     }
                 }
                 self.emit_jump_unless_terminated(cond_label);
 
                 self.instrs.push(TacInstr::Label(end_label));
+                Ok(())
             }
             Stmt::DoWhile(cond, body, _) => {
                 let body_label = self.labels.fresh();
@@ -234,10 +258,10 @@ impl Lowerer {
                         break_label: Some(end_label),
                         continue_label: Some(cond_label),
                     },
-                );
+                )?;
 
                 self.instrs.push(TacInstr::Label(cond_label));
-                let cond = self.lower_expr(cond);
+                let cond = self.lower_expr(cond)?;
                 self.instrs.push(TacInstr::CondJump {
                     cond,
                     then_label: body_label,
@@ -245,33 +269,45 @@ impl Lowerer {
                 });
 
                 self.instrs.push(TacInstr::Label(end_label));
+                Ok(())
             }
             Stmt::Break(_) => {
-                let label = control
-                    .break_label
-                    .expect("break fora de loop/switch nao pode ser baixado");
+                let label = control.break_label.ok_or_else(|| {
+                    codegen_error("break fora de loop/switch nao suportado", Some("break"))
+                })?;
                 self.instrs.push(TacInstr::Jump { label });
+                Ok(())
             }
             Stmt::Continue(_) => {
-                let label = control
-                    .continue_label
-                    .expect("continue fora de loop nao pode ser baixado");
+                let label = control.continue_label.ok_or_else(|| {
+                    codegen_error("continue fora de loop nao suportado", Some("continue"))
+                })?;
                 self.instrs.push(TacInstr::Jump { label });
+                Ok(())
             }
             Stmt::ExprStmt(expr, _) => {
-                self.lower_expr(expr);
+                self.lower_expr(expr)?;
+                Ok(())
             }
             Stmt::Return(expr, _) => {
-                let val = expr.as_ref().map(|expr| self.lower_expr(expr));
+                let val = expr
+                    .as_ref()
+                    .map(|expr| self.lower_expr(expr))
+                    .transpose()?;
                 self.instrs.push(TacInstr::Return { val });
+                Ok(())
             }
             Stmt::VarDecl(_, name, init, _) => {
                 if let Some(init) = init {
-                    let src = self.lower_expr(init);
-                    self.emit_copy(Operand::Var(name.clone()), src);
+                    let src = self.lower_expr(init)?;
+                    self.emit_copy(Operand::Var(name.clone()), src)?;
                 }
+                Ok(())
             }
-            Stmt::Switch(_, _, _) => panic!("lowering ainda nao suporta switch"),
+            Stmt::Switch(_, _, _) => Err(codegen_error(
+                "switch nao suportado no lowering",
+                Some("switch"),
+            )),
         }
     }
 
@@ -283,8 +319,8 @@ impl Lowerer {
         self.temps.fresh()
     }
 
-    fn lower_prefix(&mut self, op: &PrefixOp, target: &Expr) -> Operand {
-        let dst = self.lower_assignment_target(target);
+    fn lower_prefix(&mut self, op: &PrefixOp, target: &Expr) -> LowerResult<Operand> {
+        let dst = self.lower_assignment_target(target)?;
         let temp = self.fresh_temp();
         self.instrs.push(TacInstr::BinOp {
             dst: temp,
@@ -292,14 +328,14 @@ impl Lowerer {
             lhs: dst.clone(),
             rhs: Operand::Const(ConstValue::Int(1)),
         });
-        self.emit_copy(dst.clone(), Operand::Temp(temp));
-        dst
+        self.emit_copy(dst.clone(), Operand::Temp(temp))?;
+        Ok(dst)
     }
 
-    fn lower_postfix(&mut self, op: &PostfixOp, target: &Expr) -> Operand {
-        let dst = self.lower_assignment_target(target);
+    fn lower_postfix(&mut self, op: &PostfixOp, target: &Expr) -> LowerResult<Operand> {
+        let dst = self.lower_assignment_target(target)?;
         let old = self.fresh_temp();
-        self.emit_copy(Operand::Temp(old), dst.clone());
+        self.emit_copy(Operand::Temp(old), dst.clone())?;
 
         let new = self.fresh_temp();
         self.instrs.push(TacInstr::BinOp {
@@ -308,21 +344,30 @@ impl Lowerer {
             lhs: dst.clone(),
             rhs: Operand::Const(ConstValue::Int(1)),
         });
-        self.emit_copy(dst, Operand::Temp(new));
-        Operand::Temp(old)
+        self.emit_copy(dst, Operand::Temp(new))?;
+        Ok(Operand::Temp(old))
     }
 
-    fn lower_assignment_target(&mut self, expr: &Expr) -> Operand {
+    fn lower_assignment_target(&mut self, expr: &Expr) -> LowerResult<Operand> {
         match expr {
-            Expr::Ident(name, _) => Operand::Var(name.clone()),
-            _ => panic!("lowering ainda nao suporta esse destino de atribuicao"),
+            Expr::Ident(name, _) => Ok(Operand::Var(name.clone())),
+            _ => Err(codegen_error(
+                "destino de atribuicao nao suportado no lowering",
+                Some("assign"),
+            )),
         }
     }
 
-    fn emit_copy(&mut self, dst: Operand, src: Operand) {
+    fn emit_copy(&mut self, dst: Operand, src: Operand) -> LowerResult<()> {
         match dst {
-            Operand::Temp(_) | Operand::Var(_) => self.instrs.push(TacInstr::Copy { dst, src }),
-            Operand::Const(_) => panic!("constante nao pode ser destino de copia"),
+            Operand::Temp(_) | Operand::Var(_) => {
+                self.instrs.push(TacInstr::Copy { dst, src });
+                Ok(())
+            }
+            Operand::Const(_) => Err(codegen_error(
+                "constante nao pode ser destino de copia",
+                Some("copy"),
+            )),
         }
     }
 
@@ -342,47 +387,50 @@ impl Default for Lowerer {
     }
 }
 
-pub fn lower_function(decl: &Decl) -> TacFunction {
+pub fn lower_function(decl: &Decl) -> LowerResult<TacFunction> {
     match decl {
         Decl::Function(_, name, params, body, _) => {
             let mut lowerer = Lowerer::new();
             for stmt in body {
-                lowerer.lower_stmt(stmt);
+                lowerer.lower_stmt(stmt)?;
             }
 
-            TacFunction {
+            Ok(TacFunction {
                 name: name.clone(),
                 params: params.iter().map(|(_, name)| name.clone()).collect(),
                 instrs: lowerer.finish(),
-            }
+            })
         }
-        _ => panic!("lower_function espera Decl::Function"),
+        _ => Err(codegen_error(
+            "lower_function espera Decl::Function",
+            Some("lower_function"),
+        )),
     }
 }
 
-pub fn lower_program(prog: &Program) -> TacProgram {
-    TacProgram {
-        functions: prog
-            .decls
-            .iter()
-            .filter(|decl| matches!(decl, Decl::Function(..)))
-            .map(lower_function)
-            .collect(),
+pub fn lower_program(prog: &Program) -> LowerResult<TacProgram> {
+    let mut functions = Vec::new();
+    for decl in &prog.decls {
+        if matches!(decl, Decl::Function(..)) {
+            functions.push(lower_function(decl)?);
+        }
     }
+
+    Ok(TacProgram { functions })
 }
 
 /// Gera o TAC e aplica todas as otimizações básicas (constant folding,
 /// constant propagation e dead code elimination) até ponto fixo.
 ///
 /// Este é o ponto de entrada recomendado para a pipeline de compilação.
-pub fn lower_and_optimize(prog: &Program) -> TacProgram {
+pub fn lower_and_optimize(prog: &Program) -> LowerResult<TacProgram> {
     use crate::codegen::inter::optimizations::optimize_function;
 
-    let mut tac = lower_program(prog);
+    let mut tac = lower_program(prog)?;
     for func in &mut tac.functions {
         optimize_function(&mut func.instrs);
     }
-    tac
+    Ok(tac)
 }
 
 fn lower_literal(value: &Literal) -> ConstValue {
@@ -408,15 +456,25 @@ fn postfix_bin_op(op: &PostfixOp) -> BinOp {
     }
 }
 
-fn type_size(ty: &Type) -> i64 {
+fn type_size(ty: &Type) -> LowerResult<i64> {
     match ty {
-        Type::Char => 1,
-        Type::Short => 2,
-        Type::Int | Type::Float | Type::Enum(_) => 4,
-        Type::Long | Type::Double | Type::Pointer(_) => 8,
+        Type::Char => Ok(1),
+        Type::Short => Ok(2),
+        Type::Int | Type::Float | Type::Enum(_) => Ok(4),
+        Type::Long | Type::Double | Type::Pointer(_) => Ok(8),
         Type::Array(_) | Type::Void | Type::Struct(_) | Type::Alias(_) | Type::Function(_, _) => {
-            panic!("lowering de sizeof(type) requer layout/tamanho completo")
+            Err(codegen_error(
+                "lowering de sizeof(type) requer layout/tamanho completo",
+                Some("sizeof"),
+            ))
         }
+    }
+}
+
+fn codegen_error(message: &str, instruction: Option<&str>) -> CodegenError {
+    CodegenError {
+        message: message.to_string(),
+        instruction: instruction.map(str::to_string),
     }
 }
 
@@ -458,7 +516,7 @@ mod tests {
         let expr = Expr::Binary(Box::new(int(2)), BinOp::Add, Box::new(int(3)), span());
         let mut lowerer = Lowerer::new();
 
-        let result = lowerer.lower_expr(&expr);
+        let result = lowerer.lower_expr(&expr).unwrap();
 
         assert_eq!(result, Operand::Temp(TempId(0)));
         assert_eq!(
@@ -492,7 +550,7 @@ mod tests {
         );
         let mut lowerer = Lowerer::new();
 
-        lowerer.lower_stmt(&stmt);
+        lowerer.lower_stmt(&stmt).unwrap();
         let instrs = lowerer.finish();
 
         assert!(matches!(
@@ -537,7 +595,7 @@ mod tests {
         );
         let mut lowerer = Lowerer::new();
 
-        lowerer.lower_stmt(&stmt);
+        lowerer.lower_stmt(&stmt).unwrap();
         let instrs = lowerer.finish();
 
         assert_eq!(instrs[0], TacInstr::Label(LabelId(0)));
@@ -560,7 +618,7 @@ mod tests {
         let expr = Expr::Call(Box::new(ident("sum")), vec![arg0, int(3)], span());
         let mut lowerer = Lowerer::new();
 
-        let result = lowerer.lower_expr(&expr);
+        let result = lowerer.lower_expr(&expr).unwrap();
         let instrs = lowerer.finish();
 
         assert_eq!(result, Operand::Temp(TempId(1)));
@@ -580,7 +638,7 @@ mod tests {
         let expr = Expr::Binary(Box::new(int(2)), BinOp::Add, Box::new(rhs), span());
         let mut lowerer = Lowerer::new();
 
-        let result = lowerer.lower_expr(&expr);
+        let result = lowerer.lower_expr(&expr).unwrap();
 
         assert_eq!(result, Operand::Temp(TempId(1)));
         assert_eq!(
@@ -612,7 +670,7 @@ mod tests {
             span(),
         );
 
-        let func = lower_function(&decl);
+        let func = lower_function(&decl).unwrap();
 
         assert_eq!(func.name, "main");
         assert_eq!(func.params, vec!["argc"]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ fn main() -> std::io::Result<()> {
             eprintln!("  --only-parse           Stop after parsing");
             eprintln!("  --only-semantic        Stop after semantic analysis");
             eprintln!("  -o <file>              Set the output file path");
+            eprintln!("  --out-dir <dir>        Set the output directory");
+            eprintln!("  --out-name <name>      Set the output file name");
             eprintln!("  --emit=asm             Stop after emitting x86-64 assembly (.s)");
             eprintln!("  --emit=obj             Stop after assembling an object file (.o)");
             eprintln!("  --emit=exe             Link a runnable executable (default)");
@@ -77,6 +79,8 @@ impl EmitKind {
 struct CliArgs {
     input_file: Option<String>,
     output_file: Option<String>,
+    output_dir: Option<String>,
+    output_name: Option<String>,
     dump_tokens: bool,
     dump_ast: bool,
     dump_ir: bool,
@@ -92,6 +96,8 @@ impl CliArgs {
         let mut cli = CliArgs {
             input_file: None,
             output_file: None,
+            output_dir: None,
+            output_name: None,
             dump_tokens: false,
             dump_ast: false,
             dump_ir: false,
@@ -121,6 +127,22 @@ impl CliArgs {
                         exit(64);
                     };
                     cli.output_file = Some(path.clone());
+                }
+                "--out-dir" => {
+                    i += 1;
+                    let Some(path) = args.get(i) else {
+                        eprintln!("error: missing value for --out-dir");
+                        exit(64);
+                    };
+                    cli.output_dir = Some(path.clone());
+                }
+                "--out-name" => {
+                    i += 1;
+                    let Some(name) = args.get(i) else {
+                        eprintln!("error: missing value for --out-name");
+                        exit(64);
+                    };
+                    cli.output_name = Some(name.clone());
                 }
                 _ if arg.starts_with("--emit=") => {
                     let value = arg.strip_prefix("--emit=").unwrap();
@@ -276,7 +298,13 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
     let tac_program = lower_program(&program).map_err(|e| Box::new(e) as Box<dyn ToReport>)?;
     let asm = last::emit_program(&tac_program).map_err(|e| Box::new(e) as Box<dyn ToReport>)?;
 
-    let output_path = output_path_for(&args.input_file, &args.output_file, args.emit);
+    let output_path = output_path_for(
+        &args.input_file,
+        &args.output_file,
+        &args.output_dir,
+        &args.output_name,
+        args.emit,
+    );
     emit_artifact(&asm, &output_path, args.emit)?;
     eprintln!(
         "emitted {}: {}",
@@ -292,21 +320,35 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
 fn output_path_for(
     input: &Option<String>,
     output_override: &Option<String>,
+    output_dir: &Option<String>,
+    output_name: &Option<String>,
     emit: EmitKind,
 ) -> PathBuf {
     if let Some(path) = output_override {
         return PathBuf::from(path);
     }
 
-    match emit {
-        EmitKind::Exe => PathBuf::from("a.out"),
+    let default_name = match emit {
+        EmitKind::Exe => "a.out".to_string(),
         EmitKind::Asm | EmitKind::Obj => {
             let input = input.clone().unwrap_or_else(|| "crusty.out".to_string());
             let mut path = PathBuf::from(input);
             path.set_extension(if emit == EmitKind::Asm { "s" } else { "o" });
-            path
+            return apply_output_dir(path, output_dir);
         }
+    };
+
+    let path = PathBuf::from(output_name.clone().unwrap_or(default_name));
+    apply_output_dir(path, output_dir)
+}
+
+fn apply_output_dir(mut path: PathBuf, output_dir: &Option<String>) -> PathBuf {
+    if let Some(dir) = output_dir {
+        let mut full = PathBuf::from(dir);
+        full.push(path);
+        path = full;
     }
+    path
 }
 
 fn emit_kind_label(emit: EmitKind) -> &'static str {
@@ -455,12 +497,29 @@ mod tests {
         let parsed = CliArgs::parse(&args(&["crusty", "main.c"]));
         assert_eq!(parsed.emit, EmitKind::Exe);
         assert_eq!(parsed.output_file, None);
+        assert_eq!(parsed.output_dir, None);
+        assert_eq!(parsed.output_name, None);
     }
 
     #[test]
     fn parses_output_flag() {
         let parsed = CliArgs::parse(&args(&["crusty", "-o", "prog", "main.c"]));
         assert_eq!(parsed.output_file, Some("prog".to_string()));
+        assert_eq!(parsed.input_file, Some("main.c".to_string()));
+    }
+
+    #[test]
+    fn parses_output_dir_and_name_flags() {
+        let parsed = CliArgs::parse(&args(&[
+            "crusty",
+            "--out-dir",
+            "build",
+            "--out-name",
+            "demo",
+            "main.c",
+        ]));
+        assert_eq!(parsed.output_dir, Some("build".to_string()));
+        assert_eq!(parsed.output_name, Some("demo".to_string()));
         assert_eq!(parsed.input_file, Some("main.c".to_string()));
     }
 
@@ -492,15 +551,15 @@ mod tests {
     fn output_path_defaults_per_emit_kind() {
         let input = Some("foo/main.c".to_string());
         assert_eq!(
-            output_path_for(&input, &None, EmitKind::Asm),
+            output_path_for(&input, &None, &None, &None, EmitKind::Asm),
             PathBuf::from("foo/main.s")
         );
         assert_eq!(
-            output_path_for(&input, &None, EmitKind::Obj),
+            output_path_for(&input, &None, &None, &None, EmitKind::Obj),
             PathBuf::from("foo/main.o")
         );
         assert_eq!(
-            output_path_for(&input, &None, EmitKind::Exe),
+            output_path_for(&input, &None, &None, &None, EmitKind::Exe),
             PathBuf::from("a.out")
         );
     }
@@ -511,9 +570,24 @@ mod tests {
         let output = Some("custom_out".to_string());
         for emit in [EmitKind::Asm, EmitKind::Obj, EmitKind::Exe] {
             assert_eq!(
-                output_path_for(&input, &output, emit),
+                output_path_for(&input, &output, &None, &None, emit),
                 PathBuf::from("custom_out")
             );
         }
+    }
+
+    #[test]
+    fn output_path_joins_directory_and_name() {
+        let input = Some("src/main.c".to_string());
+        assert_eq!(
+            output_path_for(
+                &input,
+                &None,
+                &Some("build".to_string()),
+                &Some("demo".to_string()),
+                EmitKind::Exe,
+            ),
+            PathBuf::from("build/demo")
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,8 +273,8 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
     opt_pipeline.run(&mut cfg, 10);
 
     // ── Stage 5: Code generation (x86-64 / AT&T) ─────────────────────────────
-    let tac_program = lower_program(&program);
-    let asm = last::emit_program(&tac_program);
+    let tac_program = lower_program(&program).map_err(|e| Box::new(e) as Box<dyn ToReport>)?;
+    let asm = last::emit_program(&tac_program).map_err(|e| Box::new(e) as Box<dyn ToReport>)?;
 
     let output_path = output_path_for(&args.input_file, &args.output_file, args.emit);
     emit_artifact(&asm, &output_path, args.emit)?;

--- a/tests/codegen_smoke.rs
+++ b/tests/codegen_smoke.rs
@@ -82,7 +82,7 @@ fn write_temp_source(name: &str, contents: &str) -> PathBuf {
 fn smoke_assembles_with_gcc() {
     require_gcc!();
 
-    let asm = emit_program(&build_soma_program());
+    let asm = emit_program(&build_soma_program()).unwrap();
     let source = write_temp_source("assemble", &asm);
     let object = source.with_extension("o");
 
@@ -107,7 +107,7 @@ fn smoke_assembles_with_gcc() {
 fn smoke_links_and_runs_with_expected_exit_code() {
     require_gcc!();
 
-    let asm = emit_program(&build_soma_program());
+    let asm = emit_program(&build_soma_program()).unwrap();
     let source = write_temp_source("run", &asm);
     let exe = source.with_extension("bin");
 
@@ -148,7 +148,7 @@ fn smoke_simple_return_const_runs() {
         }],
     };
 
-    let asm = emit_program(&prog);
+    let asm = emit_program(&prog).unwrap();
     let source = write_temp_source("const", &asm);
     let exe = source.with_extension("bin");
 
@@ -254,7 +254,7 @@ fn smoke_call_with_more_than_six_args_runs() {
         functions: vec![sum9, main],
     };
 
-    let asm = emit_program(&prog);
+    let asm = emit_program(&prog).unwrap();
     let source = write_temp_source("manyargs", &asm);
     let exe = source.with_extension("bin");
 
@@ -306,7 +306,7 @@ fn smoke_control_flow_if_else_runs() {
         }],
     };
 
-    let asm = emit_program(&prog);
+    let asm = emit_program(&prog).unwrap();
     let source = write_temp_source("ifelse", &asm);
     let exe = source.with_extension("bin");
 

--- a/tests/exe_smoke_test.rs
+++ b/tests/exe_smoke_test.rs
@@ -60,8 +60,8 @@ fn compile_to_asm(source: &str) -> String {
         "erros semanticos inesperados: {sem_errors:?}"
     );
 
-    let tac_program = lower_program(&program);
-    emit_program(&tac_program)
+    let tac_program = lower_program(&program).unwrap();
+    emit_program(&tac_program).unwrap()
 }
 
 /// Compila `source` (C) ate um executavel real via `gcc` e o executa,


### PR DESCRIPTION
Closes #159

This branch turns the known lowering/backend panic paths into controlled `Result` errors and updates the CLI/tests to handle them.

Criei flags uteis para renomeação de arquivos compilados em .out, permitindo fazer ./diretorio/nome_do_programa

Validation:
- `cargo test -q`