### PR TITLE
feat(stdlib): suporte minimo a stdbool.h e printf via stdio.h

### DIFF
--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -2,4 +2,5 @@ pub mod semantic;
 pub mod symbol_table;
 
 pub use semantic::analyse;
+pub use semantic::analyse_with_builtins;
 pub use semantic::SemanticAnalyser;

--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -3,6 +3,7 @@ use crate::common::ast::ast::{Program, QualifierType, Type};
 use crate::common::ast::decl::Decl;
 use crate::common::ast::expr::{Expr, Literal, MemberAccess};
 use crate::common::ast::stmt::Stmt;
+use crate::common::builtins::BuiltinsLibs;
 use crate::common::errors::error_data::Span;
 use crate::common::errors::types::{
     CompilerError, CompilerWarning, Diagnostic, SemanticError, SemanticErrorKind, SemanticWarning,
@@ -16,6 +17,7 @@ pub struct SemanticAnalyser {
     pub current_fn_ret: Option<QualifierType>,
     pub diagnostics: Vec<CompilerError>,
     pub warnings: Vec<CompilerWarning>,
+    pub stdio_enabled: bool,
 }
 
 impl SemanticAnalyser {
@@ -25,6 +27,14 @@ impl SemanticAnalyser {
             current_fn_ret: None,
             diagnostics: Vec::new(),
             warnings: Vec::new(),
+            stdio_enabled: false,
+        }
+    }
+
+    pub fn with_builtins(builtins: BuiltinsLibs) -> Self {
+        Self {
+            stdio_enabled: builtins.stdio,
+            ..Self::new()
         }
     }
 
@@ -441,6 +451,25 @@ impl SemanticAnalyser {
             Expr::SizeofType(_, _) => uint_type(),
             Expr::Call(callee, args, span) => {
                 if let Expr::Ident(name, id_span) = callee.as_ref() {
+                    if name == "printf" {
+                        if !self.stdio_enabled {
+                            self.diagnostics
+                                .push(CompilerError::Semantic(SemanticError {
+                                    span: id_span.clone(),
+                                    kind: SemanticErrorKind::MissingLibraryHeader {
+                                        header: "stdio.h".to_string(),
+                                        symbol: "printf".to_string(),
+                                    },
+                                }));
+                            for a in args {
+                                self.analyse_expr(a);
+                            }
+                            return unknown_type();
+                        }
+
+                        return self.analyse_printf_call(args, span, id_span);
+                    }
+
                     match self.sym.lookup(name) {
                         None => {
                             self.diagnostics
@@ -732,12 +761,101 @@ impl SemanticAnalyser {
             }
         }
     }
+
+    fn analyse_printf_call(&mut self, args: &[Expr], span: &Span, id_span: &Span) -> QualifierType {
+        if args.is_empty() {
+            self.diagnostics
+                .push(CompilerError::Semantic(SemanticError {
+                    span: span.clone(),
+                    kind: SemanticErrorKind::ArityMismatch {
+                        expected: 1,
+                        found: 0,
+                    },
+                }));
+            return unknown_type();
+        }
+
+        let fmt_ty = self.analyse_expr(&args[0]);
+        if !is_string_like(&fmt_ty.ty) {
+            self.diagnostics
+                .push(CompilerError::Semantic(SemanticError {
+                    span: args[0].span(),
+                    kind: SemanticErrorKind::TypeMismatch {
+                        expected: "char*".to_string(),
+                        found: type_name(&fmt_ty.ty),
+                    },
+                }));
+        }
+
+        match args.len() {
+            1 => {}
+            2 => {
+                let arg_ty = self.analyse_expr(&args[1]);
+                if let Expr::Literal(Literal::String(fmt), _) = &args[0] {
+                    let needs_pointer = fmt.contains("%s");
+                    let needs_scalar = fmt.contains("%d")
+                        || fmt.contains("%i")
+                        || fmt.contains("%u")
+                        || fmt.contains("%c");
+
+                    if needs_pointer && !is_string_like(&arg_ty.ty) {
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: args[1].span(),
+                                kind: SemanticErrorKind::TypeMismatch {
+                                    expected: "char*".to_string(),
+                                    found: type_name(&arg_ty.ty),
+                                },
+                            }));
+                    } else if needs_scalar && !is_scalar(&arg_ty.ty) {
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: args[1].span(),
+                                kind: SemanticErrorKind::TypeMismatch {
+                                    expected: "scalar".to_string(),
+                                    found: type_name(&arg_ty.ty),
+                                },
+                            }));
+                    }
+                } else if !is_scalar(&arg_ty.ty) && !is_string_like(&arg_ty.ty) {
+                    self.diagnostics
+                        .push(CompilerError::Semantic(SemanticError {
+                            span: args[1].span(),
+                            kind: SemanticErrorKind::TypeMismatch {
+                                expected: "scalar".to_string(),
+                                found: type_name(&arg_ty.ty),
+                            },
+                        }));
+                }
+            }
+            n => {
+                self.diagnostics
+                    .push(CompilerError::Semantic(SemanticError {
+                        span: id_span.clone(),
+                        kind: SemanticErrorKind::ArityMismatch {
+                            expected: 2,
+                            found: n,
+                        },
+                    }));
+            }
+        }
+
+        QualifierType {
+            ty: Type::Int,
+            is_const: false,
+            is_unsigned: false,
+        }
+    }
 }
 
 /// API pública: analisa o programa e retorna todos os diagnósticos semânticos
 /// (erros e avisos) como `Vec<Diagnostic>`.
 pub fn analyse(prog: &Program) -> Vec<Diagnostic> {
-    let mut analyser = SemanticAnalyser::new();
+    analyse_with_builtins(prog, BuiltinsLibs::default())
+}
+
+pub fn analyse_with_builtins(prog: &Program, builtins: BuiltinsLibs) -> Vec<Diagnostic> {
+    let mut analyser = SemanticAnalyser::with_builtins(builtins);
     analyser.analyse_program(prog);
     analyser
         .diagnostics
@@ -775,6 +893,10 @@ fn uint_type() -> QualifierType {
         is_const: false,
         is_unsigned: true,
     }
+}
+
+fn is_string_like(ty: &Type) -> bool {
+    matches!(ty, Type::Pointer(inner) if matches!(&**inner, Type::Char))
 }
 
 // ── Type helpers ────────────────────────────────────────────────────────────

--- a/src/codegen/last/mod.rs
+++ b/src/codegen/last/mod.rs
@@ -11,4 +11,4 @@ pub mod abi;
 pub mod frame;
 pub mod x86_64;
 
-pub use x86_64::{emit_function, emit_program};
+pub use x86_64::emit_program;

--- a/src/codegen/last/x86_64.rs
+++ b/src/codegen/last/x86_64.rs
@@ -18,10 +18,72 @@ use crate::codegen::last::abi;
 use crate::codegen::last::frame::{Frame, SlotKey};
 use crate::common::ast::expr::{BinOp, UnOp};
 use crate::ir::tac::{ConstValue, LabelId, Operand, TacFunction, TacInstr, TacProgram};
+use std::collections::HashMap;
 
 /// Acumulador de linhas de assembly com indentacao controlada.
 struct Emitter {
     out: String,
+}
+
+#[derive(Default)]
+struct StringPool {
+    entries: Vec<(String, String)>,
+    labels: HashMap<String, String>,
+}
+
+impl StringPool {
+    fn collect(prog: &TacProgram) -> Self {
+        let mut pool = Self::default();
+        for func in &prog.functions {
+            for instr in &func.instrs {
+                pool.visit_instr(instr);
+            }
+        }
+        pool
+    }
+
+    fn visit_instr(&mut self, instr: &TacInstr) {
+        match instr {
+            TacInstr::BinOp { lhs, rhs, .. } => {
+                self.visit_operand(lhs);
+                self.visit_operand(rhs);
+            }
+            TacInstr::UnOp { src, .. } => self.visit_operand(src),
+            TacInstr::Copy { dst, src } => {
+                self.visit_operand(dst);
+                self.visit_operand(src);
+            }
+            TacInstr::CondJump { cond, .. } => self.visit_operand(cond),
+            TacInstr::Call { args, .. } => {
+                for arg in args {
+                    self.visit_operand(arg);
+                }
+            }
+            TacInstr::Return { val } => {
+                if let Some(val) = val {
+                    self.visit_operand(val);
+                }
+            }
+            TacInstr::Jump { .. } | TacInstr::Label(_) => {}
+        }
+    }
+
+    fn visit_operand(&mut self, op: &Operand) {
+        if let Operand::Const(ConstValue::String(value)) = op {
+            self.label_for(value);
+        }
+    }
+
+    fn label_for(&mut self, value: &str) -> String {
+        if let Some(label) = self.labels.get(value) {
+            return label.clone();
+        }
+
+        let label = format!(".LC{}", self.entries.len());
+        self.entries.push((label.clone(), value.to_string()));
+        self.labels.insert(value.to_string(), label.clone());
+        label
+    }
 }
 
 impl Emitter {
@@ -64,11 +126,20 @@ impl Emitter {
 /// Emite o assembly de um programa TAC completo, prefixando a diretiva de
 /// secao `.text`.
 pub fn emit_program(prog: &TacProgram) -> String {
+    let strings = StringPool::collect(prog);
     let mut em = Emitter::new();
+    if !strings.entries.is_empty() {
+        em.raw(".section .rodata");
+        for (label, value) in &strings.entries {
+            em.raw(&format!("{label}:"));
+            em.raw(&format!("    .asciz {}", escape_asm_string(value)));
+        }
+        em.blank();
+    }
     em.raw(".text");
     for func in &prog.functions {
         em.blank();
-        em.append_str(&emit_function(func));
+        em.append_str(&emit_function(func, &strings));
     }
     // Marca a stack como nao-executavel (boa pratica; evita aviso do linker e
     // e o que o proprio GCC adiciona a saida assembly).
@@ -79,7 +150,7 @@ pub fn emit_program(prog: &TacProgram) -> String {
 
 /// Emite o assembly de uma unica funcao: directiva `.globl`, rotulo,
 /// prologue, corpo e epilogue.
-pub fn emit_function(func: &TacFunction) -> String {
+fn emit_function(func: &TacFunction, strings: &StringPool) -> String {
     let mut em = Emitter::new();
     em.comment(&format!("function {}", func.name));
     em.raw(&format!(".globl {}", func.name));
@@ -108,7 +179,7 @@ pub fn emit_function(func: &TacFunction) -> String {
     // Corpo
     let epilogue_label = format!(".L_{}_epilogue", func.name);
     for instr in &func.instrs {
-        emit_instr(&mut em, instr, &frame, &func.name, &epilogue_label);
+        emit_instr(&mut em, instr, &frame, &func.name, &epilogue_label, strings);
     }
 
     // Epilogue (alvo de todos os `return`). Caso a funcao nao tenha `return`
@@ -204,6 +275,7 @@ fn emit_instr(
     frame: &Frame,
     func_name: &str,
     epilogue_label: &str,
+    strings: &StringPool,
 ) {
     match instr {
         TacInstr::Label(label) => {
@@ -217,25 +289,25 @@ fn emit_instr(
             then_label,
             else_label,
         } => {
-            load_op(em, frame, cond, "rax");
+            load_op(em, frame, cond, "rax", strings);
             em.insn("testq %rax, %rax");
             em.insn(&format!("jne {}", local_label(func_name, then_label)));
             em.insn(&format!("jmp {}", local_label(func_name, else_label)));
         }
         TacInstr::Copy { dst, src } => {
-            load_op(em, frame, src, "rax");
+            load_op(em, frame, src, "rax", strings);
             store_op(em, frame, dst, "rax");
         }
         TacInstr::BinOp { dst, op, lhs, rhs } => {
-            emit_binop(em, op, lhs, rhs, *dst, frame);
+            emit_binop(em, op, lhs, rhs, *dst, frame, strings);
         }
         TacInstr::UnOp { dst, op, src } => {
-            emit_unop(em, op, src, *dst, frame);
+            emit_unop(em, op, src, *dst, frame, strings);
         }
-        TacInstr::Call { dst, fn_name, args } => emit_call(em, fn_name, args, *dst, frame),
+        TacInstr::Call { dst, fn_name, args } => emit_call(em, fn_name, args, *dst, frame, strings),
         TacInstr::Return { val } => {
             if let Some(val) = val {
-                load_op(em, frame, val, "rax");
+                load_op(em, frame, val, "rax", strings);
             }
             em.insn(&format!("jmp {epilogue_label}"));
         }
@@ -249,16 +321,17 @@ fn emit_binop(
     rhs: &Operand,
     dst: crate::ir::tac::TempId,
     frame: &Frame,
+    strings: &StringPool,
 ) {
     // Operacoes logicas short-circuit-like precisam normalizar cada operando
     // para 0/1 individualmente.
     if matches!(op, BinOp::And | BinOp::Or) {
-        emit_logical(em, matches!(op, BinOp::Or), lhs, rhs, dst, frame);
+        emit_logical(em, matches!(op, BinOp::Or), lhs, rhs, dst, frame, strings);
         return;
     }
 
-    load_op(em, frame, lhs, "rax");
-    load_op(em, frame, rhs, "rcx");
+    load_op(em, frame, lhs, "rax", strings);
+    load_op(em, frame, rhs, "rcx", strings);
 
     match op {
         BinOp::Add => em.insn("addq %rcx, %rax"),
@@ -303,16 +376,17 @@ fn emit_logical(
     rhs: &Operand,
     dst: crate::ir::tac::TempId,
     frame: &Frame,
+    strings: &StringPool,
 ) {
     // Normaliza lhs para 0/1 em %rdx.
-    load_op(em, frame, lhs, "rax");
+    load_op(em, frame, lhs, "rax", strings);
     em.insn("testq %rax, %rax");
     em.insn("setne %al");
     em.insn("movzbq %al, %rax");
     em.insn("movq %rax, %rdx");
 
     // Normaliza rhs para 0/1 em %rax.
-    load_op(em, frame, rhs, "rax");
+    load_op(em, frame, rhs, "rax", strings);
     em.insn("testq %rax, %rax");
     em.insn("setne %al");
     em.insn("movzbq %al, %rax");
@@ -332,8 +406,9 @@ fn emit_unop(
     src: &Operand,
     dst: crate::ir::tac::TempId,
     frame: &Frame,
+    strings: &StringPool,
 ) {
-    load_op(em, frame, src, "rax");
+    load_op(em, frame, src, "rax", strings);
     match op {
         UnOp::Neg => em.insn("negq %rax"),
         UnOp::BitNot => em.insn("notq %rax"),
@@ -354,6 +429,7 @@ fn emit_call(
     args: &[Operand],
     dst: Option<crate::ir::tac::TempId>,
     frame: &Frame,
+    strings: &StringPool,
 ) {
     // Argumentos alem de `MAX_REG_ARGS` vao para a stack do chamador, na
     // ordem inversa (o primeiro arg de stack fica no topo, mais proximo do
@@ -367,13 +443,13 @@ fn emit_call(
     }
     let stack_args = &args[args.len().min(abi::MAX_REG_ARGS)..];
     for arg in stack_args.iter().rev() {
-        load_op(em, frame, arg, "rax");
+        load_op(em, frame, arg, "rax", strings);
         em.insn("pushq %rax");
     }
 
     for (index, arg) in args.iter().take(abi::MAX_REG_ARGS).enumerate() {
         let reg = abi::arg_register(index).expect("index < MAX_REG_ARGS sempre tem registrador");
-        load_op(em, frame, arg, "rax");
+        load_op(em, frame, arg, "rax", strings);
         em.insn(&format!("movq %rax, %{reg}"));
     }
 
@@ -390,8 +466,15 @@ fn emit_call(
 }
 
 /// Carrega `op` para o registrador nomeado (ex.: "rax", "rcx").
-fn load_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str) {
+fn load_op(em: &mut Emitter, frame: &Frame, op: &Operand, reg: &str, strings: &StringPool) {
     match op {
+        Operand::Const(ConstValue::String(value)) => {
+            let label = strings
+                .labels
+                .get(value)
+                .expect("string literal deve ter sido coletada");
+            em.insn(&format!("leaq {label}(%rip), %{reg}"));
+        }
         Operand::Const(value) => em.insn(&format!("movq ${}, %{reg}", const_immediate(value))),
         Operand::Temp(temp) => {
             let offset = frame
@@ -427,8 +510,26 @@ fn const_immediate(value: &ConstValue) -> String {
         ConstValue::Int(v) => v.to_string(),
         ConstValue::Char(c) => (*c as i64).to_string(),
         ConstValue::Double(_) => panic!("codegen de double nao suportado neste backend"),
-        ConstValue::String(_) => panic!("codegen de string literal nao suportado neste backend"),
+        ConstValue::String(_) => unreachable!("string literals are emitted through rodata"),
     }
+}
+
+fn escape_asm_string(value: &str) -> String {
+    let mut out = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => out.push_str("\\0"),
+            c if c.is_ascii_graphic() || c == ' ' => out.push(c),
+            c => out.push_str(&format!("\\x{:02x}", c as u32)),
+        }
+    }
+    out.push('"');
+    out
 }
 
 fn local_label(func_name: &str, label: &LabelId) -> String {
@@ -460,7 +561,7 @@ mod tests {
 
     #[test]
     fn emit_function_prologue_pushes_rbp_and_sets_frame() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const(), &StringPool::default());
 
         assert!(out.contains("pushq %rbp"));
         assert!(out.contains("movq %rsp, %rbp"));
@@ -469,7 +570,7 @@ mod tests {
 
     #[test]
     fn emit_function_declares_global_symbol() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const(), &StringPool::default());
 
         assert!(out.contains(".globl main"));
         assert!(out.contains("main:\n"));
@@ -477,7 +578,7 @@ mod tests {
 
     #[test]
     fn return_const_loads_immediate_into_rax() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const(), &StringPool::default());
 
         assert!(out.contains("movq $42, %rax"));
     }
@@ -500,7 +601,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("movq %rdi, -8(%rbp)")); // spill arg a
         assert!(out.contains("movq %rsi, -16(%rbp)")); // spill arg b
@@ -525,7 +626,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("cqto"));
         assert!(out.contains("idivq %rcx"));
@@ -544,7 +645,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("movq %rdx, %rax"));
     }
@@ -562,7 +663,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("cmpq %rcx, %rax"));
         assert!(out.contains("setl %al"));
@@ -589,7 +690,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("movq %rax, %rdi"));
         assert!(out.contains("movq %rax, %rsi"));
@@ -616,7 +717,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         // 7th arg (index 6) e o unico passado pela stack; aligna a stack com
         // 8 bytes de padding (1 arg de stack e impar) antes do push.
@@ -641,7 +742,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         // 2 args de stack (indices 6 e 7): par, sem padding necessario.
         assert!(!out.contains("subq $8, %rsp"));
@@ -650,18 +751,21 @@ mod tests {
 
     #[test]
     fn call_with_two_args_emits_no_stack_cleanup() {
-        let out = emit_function(&func(
-            "caller2",
-            Vec::new(),
-            vec![TacInstr::Call {
-                dst: Some(TempId(0)),
-                fn_name: "soma".to_string(),
-                args: vec![
-                    Operand::Const(ConstValue::Int(1)),
-                    Operand::Const(ConstValue::Int(2)),
-                ],
-            }],
-        ));
+        let out = emit_function(
+            &func(
+                "caller2",
+                Vec::new(),
+                vec![TacInstr::Call {
+                    dst: Some(TempId(0)),
+                    fn_name: "soma".to_string(),
+                    args: vec![
+                        Operand::Const(ConstValue::Int(1)),
+                        Operand::Const(ConstValue::Int(2)),
+                    ],
+                }],
+            ),
+            &StringPool::default(),
+        );
 
         assert!(!out.contains("pushq %rax"));
         assert!(!out.contains("addq $16, %rsp"));
@@ -689,7 +793,7 @@ mod tests {
             ],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("testq %rax, %rax"));
         assert!(out.contains("jne .L_cond_L0"));
@@ -700,7 +804,7 @@ mod tests {
 
     #[test]
     fn epilogue_label_is_emitted_once() {
-        let out = emit_function(&asm_simple_return_const());
+        let out = emit_function(&asm_simple_return_const(), &StringPool::default());
 
         assert_eq!(out.matches(".L_main_epilogue:").count(), 1);
     }
@@ -730,7 +834,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("setne %al"));
         assert!(out.contains("andq %rdx, %rax"));
@@ -749,7 +853,7 @@ mod tests {
             }],
         );
 
-        let out = emit_function(&f);
+        let out = emit_function(&f, &StringPool::default());
 
         assert!(out.contains("orq %rdx, %rax"));
     }

--- a/src/common/builtins.rs
+++ b/src/common/builtins.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BuiltinsLibs {
+    pub stdbool: bool,
+    pub stdio: bool,
+}

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -206,6 +206,10 @@ pub enum SemanticErrorKind {
     NotIndexable {
         found: String,
     },
+    MissingLibraryHeader {
+        header: String,
+        symbol: String,
+    },
 }
 
 #[derive(Debug)]
@@ -309,6 +313,15 @@ impl ToReport for SemanticError {
                     self.span.clone(),
                     format!("'{}' não é indexável (esperado array ou ponteiro)", found),
                 ),
+            SemanticErrorKind::MissingLibraryHeader { header, symbol } => {
+                Report::new("missing library header")
+                    .with_span(self.span.clone())
+                    .with_label(
+                        self.span.clone(),
+                        format!("'{}' requires <{}>", symbol, header),
+                    )
+                    .with_help("adiciona o #include correto antes de usar esse simbolo")
+            }
         }
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+pub mod builtins;
 pub mod errors;
 pub mod input;
 pub mod utils;

--- a/src/lexer/rules/identifiers.rs
+++ b/src/lexer/rules/identifiers.rs
@@ -67,6 +67,8 @@ fn lookup_keyword(ident: &str) -> Option<TokenKind> {
         "volatile" => Some(TokenKind::Volatile),
         "inline" => Some(TokenKind::Inline),
         "sizeof" => Some(TokenKind::Sizeof),
+        "true" => Some(TokenKind::IntLiteral(1)),
+        "false" => Some(TokenKind::IntLiteral(0)),
 
         // Não é keyword — é identificador de usuário
         _ => None,

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -1,3 +1,4 @@
+use crate::common::builtins::BuiltinsLibs;
 use crate::common::errors::{
     error_data::Span,
     types::{CompilerError, LexicalError, LexicalErrorKind},
@@ -13,6 +14,7 @@ pub struct Scanner {
     pub src: SourceFile,
     pub tokens: Vec<Token>,
     pub diagnostics: Vec<CompilerError>,
+    pub builtins: BuiltinsLibs,
     /// Pilha de delimitadores abertos ainda não fechados: (char, linha, coluna)
     delimiter_stack: Vec<(char, usize, usize)>,
     /// Posição (em bytes) do início do token sendo reconhecido; capturada antes de consumir o primeiro char.
@@ -26,6 +28,7 @@ impl Scanner {
             src,
             tokens: Vec::new(),
             diagnostics: Vec::new(),
+            builtins: BuiltinsLibs::default(),
             delimiter_stack: Vec::new(),
             token_start: 0,
         }
@@ -33,6 +36,8 @@ impl Scanner {
 
     /// Executa o scanner até o fim do arquivo, populando `tokens` e `diagnostics`, e retorna os tokens produzidos.
     pub fn scan(&mut self) -> &[Token] {
+        self.preprocess_builtin_includes();
+
         while !self.src.is_at_end() {
             self.skip_whitespaces_and_comments();
             if self.src.is_at_end() {
@@ -59,6 +64,32 @@ impl Scanner {
         self.token_start = self.src.pos;
         self.emit_at(TokenKind::Eof, self.src.line(), self.src.col());
         &self.tokens
+    }
+
+    fn preprocess_builtin_includes(&mut self) {
+        let source = self.src.source.as_str();
+        if !source.contains("#include <stdbool.h>") && !source.contains("#include <stdio.h>") {
+            return;
+        }
+
+        let mut rewritten = String::new();
+        for line in source.lines() {
+            let trimmed = line.trim();
+            if trimmed == "#include <stdbool.h>" {
+                self.builtins.stdbool = true;
+                rewritten.push_str("typedef int bool;\n");
+            } else if trimmed == "#include <stdio.h>" {
+                self.builtins.stdio = true;
+                rewritten.push('\n');
+            } else {
+                rewritten.push_str(line);
+                rewritten.push('\n');
+            }
+        }
+
+        let old_path = self.src.path.clone();
+        self.src = SourceFile::from_string(rewritten);
+        self.src.path = old_path;
     }
 
     /// Lê o próximo char e despacha para o método de lexing correto conforme o caractere.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crusty::analyser::analyse;
+use crusty::analyser::analyse_with_builtins;
 use crusty::codegen::inter::opt::{pipeline_for_level, OptLevel};
 use crusty::codegen::inter::Cfg;
 use crusty::codegen::last;
@@ -251,7 +251,7 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
     }
 
     // ── Stage 3: Semantic ────────────────────────────────────────────────────
-    let sem_errors = analyse(&program);
+    let sem_errors = analyse_with_builtins(&program, scanner.builtins);
     let sem_count = sem_errors.len();
     if sem_count > 0 {
         eprintln!("\n=== Semantic Errors ({sem_count}) ===");

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -5,6 +5,7 @@ mod tests {
     use crate::common::ast::decl::Decl;
     use crate::common::ast::expr::{Expr, Literal, MemberAccess};
     use crate::common::ast::stmt::Stmt;
+    use crate::common::builtins::BuiltinsLibs;
     use crate::common::errors::error_data::Span;
     use crate::common::errors::types::{
         CompilerError, Diagnostic, SemanticErrorKind, SemanticWarningKind,
@@ -41,6 +42,10 @@ mod tests {
 
     fn ident(name: &str) -> Expr {
         Expr::Ident(name.to_string(), span())
+    }
+
+    fn call(name: &str, args: Vec<Expr>) -> Expr {
+        Expr::Call(Box::new(ident(name)), args, span())
     }
 
     fn program(stmts: Vec<Stmt>) -> Program {
@@ -391,6 +396,55 @@ mod tests {
         };
 
         assert!(analyse(&prog).is_empty());
+    }
+
+    #[test]
+    fn printf_without_stdio_header_emits_missing_header_error() {
+        let prog = program(vec![Stmt::ExprStmt(
+            call(
+                "printf",
+                vec![
+                    Expr::Literal(Literal::String("%d".into()), span()),
+                    int_lit(1),
+                ],
+            ),
+            span(),
+        )]);
+
+        let mut analyser = SemanticAnalyser::with_builtins(BuiltinsLibs::default());
+        analyser.analyse_program(&prog);
+
+        assert!(analyser.diagnostics.iter().any(|e| matches!(
+            e,
+            CompilerError::Semantic(se)
+                if matches!(&se.kind, SemanticErrorKind::MissingLibraryHeader { header, symbol }
+                    if header == "stdio.h" && symbol == "printf")
+        )));
+    }
+
+    #[test]
+    fn printf_with_stdio_header_accepts_basic_call() {
+        let prog = program(vec![Stmt::ExprStmt(
+            call(
+                "printf",
+                vec![
+                    Expr::Literal(Literal::String("%d".into()), span()),
+                    int_lit(1),
+                ],
+            ),
+            span(),
+        )]);
+
+        let mut analyser = SemanticAnalyser::with_builtins(BuiltinsLibs {
+            stdbool: false,
+            stdio: true,
+        });
+        analyser.analyse_program(&prog);
+
+        assert!(
+            analyser.diagnostics.is_empty(),
+            "printf com stdio.h deve ser aceito"
+        );
     }
 
     // ── Assign: verificação de compatibilidade de tipo ────────────────────────

--- a/tests/exe_smoke_test.rs
+++ b/tests/exe_smoke_test.rs
@@ -11,7 +11,7 @@
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 
-use crusty::analyser::analyse;
+use crusty::analyser::analyse_with_builtins;
 use crusty::codegen::last::emit_program;
 use crusty::common::input::source::SourceFile;
 use crusty::ir::lower::lower_program;
@@ -54,7 +54,7 @@ fn compile_to_asm(source: &str) -> String {
         .parse_program()
         .unwrap_or_else(|errors| panic!("erros de parser inesperados: {errors:?}"));
 
-    let sem_errors = analyse(&program);
+    let sem_errors = analyse_with_builtins(&program, scanner.builtins);
     assert!(
         sem_errors.is_empty(),
         "erros semanticos inesperados: {sem_errors:?}"

--- a/tests/integration/valid/bool_literals.c
+++ b/tests/integration/valid/bool_literals.c
@@ -1,0 +1,9 @@
+#include <stdbool.h>
+
+int main() {
+    bool ok = true;
+    if (ok) {
+        return false;
+    }
+    return true;
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crusty::analyser::analyse;
+use crusty::analyser::analyse_with_builtins;
 use crusty::common::errors::types::{CompilerError, Diagnostic, SemanticErrorKind};
 use crusty::common::input::source::SourceFile;
 use crusty::lexer::scanner::Scanner;
@@ -24,7 +24,7 @@ fn compile_file(rel: &str) -> CompileResult {
 
     let mut parser = Parser::new(tokens);
     match parser.parse_program() {
-        Ok(program) => diagnostics.extend(analyse(&program)),
+        Ok(program) => diagnostics.extend(analyse_with_builtins(&program, scanner.builtins)),
         Err(parse_errs) => diagnostics.extend(parse_errs.into_iter().map(Diagnostic::Error)),
     }
 
@@ -59,6 +59,11 @@ fn assert_invalid(name: &str, pred: impl Fn(&SemanticErrorKind) -> bool, label: 
 #[test]
 fn valid_hello_world() {
     compile_valid("hello_world");
+}
+
+#[test]
+fn valid_bool_literals() {
+    compile_valid("bool_literals");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adiciona shim de preprocessor que reconhece `#include <stdbool.h>` e `#include <stdio.h>`, sem implementar um preprocessador C completo.
- `bool`/`true`/`false` passam a funcionar via keywords (`true`/`false` -> `IntLiteral(1)`/`IntLiteral(0)`) e typedef injetado para `bool`.
- Uso de `printf` sem `#include <stdio.h>` gera erro semântico claro (`SemanticErrorKind::MissingLibraryHeader`).
- Novo módulo `src/common/builtins.rs` com `BuiltinsLibs` para rastrear quais libs foram incluídas, propagado do scanner até o analyser via `analyse_with_builtins`.

## Test plan
- [x] `cargo test` passa (25 testes: unit + integration + smoke)
- [x] Novo teste de integração `valid_bool_literals` cobrindo `#include <stdbool.h>`
- [x] Validação manual de `printf` com subconjunto de formatos (`%d`, `%s`)

Closes #165