### PR TITLE
feat(semantic): validação semântica mínima

### DIFF
--- a/docs/semantic.md
+++ b/docs/semantic.md
@@ -15,6 +15,9 @@ struct SemanticAnalyser {
     sym: SymbolTable,
     current_fn_ret: Option<QualifierType>,  // tipo de retorno da função atual
     diagnostics: Vec<CompilerError>,
+    warnings: Vec<CompilerWarning>,
+    loop_depth: usize,                      // para validar break/continue
+    switch_depth: usize,                    // para validar break em switch
 }
 ```
 
@@ -83,6 +86,7 @@ analyse_stmt::For     → enter_scope / exit_scope  (init pode declarar variáve
 3. Declara cada parâmetro no novo escopo
 4. Analisa todos os statements do corpo
 5. Restaura `current_fn_ret`; `exit_scope`
+6. Verifica a heurística `body_always_returns` se a função não for `void`; emite aviso `MissingReturn` se faltar retorno.
 
 ### Struct
 
@@ -170,34 +174,51 @@ Promoção numérica: `Double > Float > Long > Int > Short/Char`.
 
 | Nó | Tipo retornado |
 |---|---|
-| `Unary`, `Prefix`, `Postfix` | mesmo tipo do operando |
+| `Unary(AddrOf)` | `Pointer(T)` onde `T` é o tipo do operando |
+| `Unary(Deref)` | tipo base `T` de `Pointer(T)` ou `Array(T)` |
+| `Unary(-, ~)`, `Prefix`, `Postfix` | mesmo tipo do operando |
 | `CompoundAssign` | tipo do LHS |
 | `Cast(qty, _)` | `qty` resolvido |
 | `Sizeof(_)`, `SizeofType(_)` | `unsigned int` |
-| `Call(callee, args)` | `void` (sentinela — lookup de retorno não implementado) |
-| `Index(arr, idx)` | tipo do elemento (desreferencia `Array(T)` ou `Pointer(T)`) |
-| `Ternary(cond, then, else)` | tipo do ramo `then` |
+| `Call(callee, args)` | Tipo de retorno registrado na assinatura. Checa aridade e tipos de argumentos. |
+| `Index(arr, idx)` | tipo do elemento (desreferencia `Array(T)` ou `Pointer(T)`). `idx` deve ser numérico inteiro. |
+| `Ternary(cond, then, else)` | O tipo promovido/comum dos ramos `then` e `else`, após verificação de compatibilidade. |
 
 ---
 
-## Erros Semânticos
+## Diagnósticos Semânticos
 
-Todos são do tipo `CompilerError::Semantic(SemanticError { span, kind })`:
+Erros geram `CompilerError::Semantic`, avisos geram `CompilerWarning::Semantic`. A análise não é interrompida por diagnósticos.
+
+### Erros (CompilerError)
 
 | Kind | Causa |
 |---|---|
 | `Redeclaration(name)` | Nome já declarado no escopo atual |
 | `UndefinedVariable(name)` | Identificador não encontrado em nenhum escopo |
+| `UndefinedFunction(name)` | Chamada de função sem definição ou protótipo registrado |
 | `AssignToConst(name)` | Atribuição a variável declarada com `const` |
-| `TypeMismatch { expected, found }` | Tipos incompatíveis em atribuição ou operação binária |
+| `TypeMismatch { expected, found }` | Tipos incompatíveis (atribuição, operação binária, retorno, ternário) |
 | `UndefinedStruct(name)` | Acesso a membro de struct não registrada |
-| `FieldNotFound { struct_name, field_name }` | Campo não existe na struct |
+| `FieldNotFound { struct, field }` | Campo não existe na struct |
+| `InvalidSwitchType` | Expressão de switch não é de tipo inteiro |
+| `BreakOutsideLoop` | Uso de `break` fora de um bloco iterativo (`for`/`while`) ou `switch` |
+| `ContinueOutsideLoop` | Uso de `continue` fora de um bloco iterativo (`for`/`while`) |
+| `ArityMismatch { expected, found }` | Quantidade incorreta de argumentos na chamada de função |
+| `NotIndexable` | Tentativa de usar operador de índice `[]` em tipo que não é array nem ponteiro |
+| `InvalidIndexType` | Expressão usada no índice não é do tipo inteiro |
+
+### Avisos (CompilerWarning)
+
+| Kind | Causa |
+|---|---|
+| `MissingReturn(name)` | Função declarada com retorno não-void sem garantia de `return` em todos os caminhos |
+| `UnusedVariable(name)` | Variável local declarada mas não referenciada |
+| `MayBeUninitialized(name)`| Variável lida sem antes ter garantido inicialização (por declaração ou atribuição) |
 
 ---
 
 ## Limitações atuais (TODO)
 
-- Verificação de tipo de retorno de função (`return expr` vs. tipo declarado)
-- Lookup de tipo de retorno em chamadas de função (`Call` retorna `void` sentinela)
-- Verificação de compatibilidade entre ramos `then`/`else` no ternário
 - Aritmética de ponteiro para `Sub` (ponteiro − ponteiro → `ptrdiff_t`)
+- Constant folding robusto (hoje o compilador avalia as heurísticas baseado estaticamente na árvore do código, sem resolver valores em runtime na análise)

--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -512,22 +512,18 @@ impl SemanticAnalyser {
                         is_const: false,
                         is_unsigned: false,
                     },
-                    crate::common::ast::expr::UnOp::Deref => {
-                        match inner_ty.ty {
-                            Type::Pointer(base) | Type::Array(base) => QualifierType {
-                                ty: *base,
-                                is_const: inner_ty.is_const,
-                                is_unsigned: inner_ty.is_unsigned,
-                            },
-                            _ => inner_ty,
-                        }
-                    }
+                    crate::common::ast::expr::UnOp::Deref => match inner_ty.ty {
+                        Type::Pointer(base) | Type::Array(base) => QualifierType {
+                            ty: *base,
+                            is_const: inner_ty.is_const,
+                            is_unsigned: inner_ty.is_unsigned,
+                        },
+                        _ => inner_ty,
+                    },
                     _ => inner_ty,
                 }
             }
-            Expr::Prefix(_, e, _) | Expr::Postfix(_, e, _) => {
-                self.analyse_expr(e)
-            }
+            Expr::Prefix(_, e, _) | Expr::Postfix(_, e, _) => self.analyse_expr(e),
             Expr::CompoundAssign(_, lhs, rhs, _) => {
                 let lhs_ty = self.analyse_expr(lhs);
                 self.analyse_expr(rhs);

--- a/src/analyser/semantic.rs
+++ b/src/analyser/semantic.rs
@@ -16,6 +16,12 @@ pub struct SemanticAnalyser {
     pub current_fn_ret: Option<QualifierType>,
     pub diagnostics: Vec<CompilerError>,
     pub warnings: Vec<CompilerWarning>,
+    /// Profundidade de loops aninhados (for/while/do-while).
+    /// Usada para validar `continue` e `break`.
+    pub loop_depth: usize,
+    /// Profundidade de `switch` aninhados.
+    /// Usada para validar `break` (switch aceita break, mas não continue).
+    pub switch_depth: usize,
 }
 
 impl SemanticAnalyser {
@@ -25,6 +31,8 @@ impl SemanticAnalyser {
             current_fn_ret: None,
             diagnostics: Vec::new(),
             warnings: Vec::new(),
+            loop_depth: 0,
+            switch_depth: 0,
         }
     }
 
@@ -168,7 +176,7 @@ impl SemanticAnalyser {
                 }
 
                 self.sym.enter_scope();
-                let prev_ret = self.current_fn_ret.replace(resolved_ret);
+                let prev_ret = self.current_fn_ret.replace(resolved_ret.clone());
 
                 for (qty, name) in params {
                     let resolved_qty = self.resolve_type(qty);
@@ -191,6 +199,15 @@ impl SemanticAnalyser {
 
                 for stmt in body {
                     self.analyse_stmt(stmt);
+                }
+
+                // Aviso conservador: função não-void cujo corpo não termina com return.
+                if resolved_ret.ty != Type::Void && !body_always_returns(body) {
+                    self.warnings
+                        .push(CompilerWarning::Semantic(SemanticWarning {
+                            span: span.clone(),
+                            kind: SemanticWarningKind::MissingReturn(name.clone()),
+                        }));
                 }
 
                 self.current_fn_ret = prev_ret;
@@ -244,10 +261,23 @@ impl SemanticAnalyser {
     pub fn analyse_stmt(&mut self, stmt: &Stmt) {
         match stmt {
             Stmt::VarDecl(qty, name, init, span) => {
-                if let Some(expr) = init {
-                    self.analyse_expr(expr);
-                }
                 let resolved_qty = self.resolve_type(qty);
+                let initialized = if let Some(expr) = init {
+                    let init_ty = self.analyse_expr(expr);
+                    if !types_compatible_for_assign(&resolved_qty.ty, &init_ty.ty) {
+                        self.diagnostics
+                            .push(CompilerError::Semantic(SemanticError {
+                                span: expr.span(),
+                                kind: SemanticErrorKind::TypeMismatch {
+                                    expected: type_name(&resolved_qty.ty),
+                                    found: type_name(&init_ty.ty),
+                                },
+                            }));
+                    }
+                    true
+                } else {
+                    false
+                };
                 let symbol = Symbol {
                     name: name.clone(),
                     ty: resolved_qty.clone(),
@@ -257,7 +287,7 @@ impl SemanticAnalyser {
                     prototype_only: false,
                     // Locais começam "não usadas"; a leitura marca `used = true`.
                     used: false,
-                    initialized: init.is_some(),
+                    initialized,
                 };
                 if let Err(e) = self.sym.declare(symbol) {
                     self.diagnostics.push(e);
@@ -287,7 +317,7 @@ impl SemanticAnalyser {
                     }
                     (Some(expected), Some(e)) => {
                         let found_expr_qty = self.analyse_expr(e);
-                        if expected.ty != found_expr_qty.ty {
+                        if !types_compatible_for_assign(&expected.ty, &found_expr_qty.ty) {
                             self.diagnostics
                                 .push(CompilerError::Semantic(SemanticError {
                                     span: span.clone(),
@@ -320,10 +350,14 @@ impl SemanticAnalyser {
             }
             Stmt::While(cond, body, _) => {
                 self.analyse_expr(cond);
+                self.loop_depth += 1;
                 self.analyse_stmt(body);
+                self.loop_depth -= 1;
             }
             Stmt::DoWhile(cond, body, _) => {
+                self.loop_depth += 1;
                 self.analyse_stmt(body);
+                self.loop_depth -= 1;
                 self.analyse_expr(cond);
             }
             Stmt::For(init, cond, inc, body, _) => {
@@ -337,18 +371,56 @@ impl SemanticAnalyser {
                 if let Some(e) = inc {
                     self.analyse_expr(e);
                 }
+                self.loop_depth += 1;
                 self.analyse_stmt(body);
+                self.loop_depth -= 1;
                 self.exit_scope_checking_unused();
             }
-            Stmt::Switch(expr, cases, _) => {
-                self.analyse_expr(expr);
+            Stmt::Switch(expr, cases, span) => {
+                let disc_ty = self.analyse_expr(expr);
+                // Em C, o discriminante do switch deve ser de tipo inteiro ou enum.
+                let is_switch_ok = matches!(
+                    disc_ty.ty,
+                    Type::Int | Type::Long | Type::Short | Type::Char | Type::Enum(_)
+                );
+                if !is_switch_ok {
+                    self.diagnostics
+                        .push(CompilerError::Semantic(SemanticError {
+                            span: span.clone(),
+                            kind: SemanticErrorKind::InvalidSwitchType {
+                                found: type_name(&disc_ty.ty),
+                            },
+                        }));
+                }
+                self.switch_depth += 1;
                 for case in cases {
+                    if let crate::common::ast::stmt::SwitchLabel::Case(case_expr) = &case.label {
+                        self.analyse_expr(case_expr);
+                    }
                     for s in &case.stmts {
                         self.analyse_stmt(s);
                     }
                 }
+                self.switch_depth -= 1;
             }
-            Stmt::Break(_) | Stmt::Continue(_) => {}
+            Stmt::Break(span) => {
+                if self.loop_depth == 0 && self.switch_depth == 0 {
+                    self.diagnostics
+                        .push(CompilerError::Semantic(SemanticError {
+                            span: span.clone(),
+                            kind: SemanticErrorKind::BreakOutsideLoop,
+                        }));
+                }
+            }
+            Stmt::Continue(span) => {
+                if self.loop_depth == 0 {
+                    self.diagnostics
+                        .push(CompilerError::Semantic(SemanticError {
+                            span: span.clone(),
+                            kind: SemanticErrorKind::ContinueOutsideLoop,
+                        }));
+                }
+            }
         }
     }
 
@@ -422,7 +494,28 @@ impl SemanticAnalyser {
                     }
                 }
             }
-            Expr::Unary(_, e, _) | Expr::Prefix(_, e, _) | Expr::Postfix(_, e, _) => {
+            Expr::Unary(op, e, _) => {
+                let inner_ty = self.analyse_expr(e);
+                match op {
+                    crate::common::ast::expr::UnOp::AddrOf => QualifierType {
+                        ty: Type::Pointer(Box::new(inner_ty.ty)),
+                        is_const: false,
+                        is_unsigned: false,
+                    },
+                    crate::common::ast::expr::UnOp::Deref => {
+                        match inner_ty.ty {
+                            Type::Pointer(base) | Type::Array(base) => QualifierType {
+                                ty: *base,
+                                is_const: inner_ty.is_const,
+                                is_unsigned: inner_ty.is_unsigned,
+                            },
+                            _ => inner_ty,
+                        }
+                    }
+                    _ => inner_ty,
+                }
+            }
+            Expr::Prefix(_, e, _) | Expr::Postfix(_, e, _) => {
                 self.analyse_expr(e)
             }
             Expr::CompoundAssign(_, lhs, rhs, _) => {
@@ -745,6 +838,35 @@ pub fn analyse(prog: &Program) -> Vec<Diagnostic> {
         .map(Diagnostic::Error)
         .chain(analyser.warnings.into_iter().map(Diagnostic::Warning))
         .collect()
+}
+
+/// Heurística conservadora: retorna `true` se o último statement do corpo é
+/// `Stmt::Return(Some(_))` ou se algum statement de nível de topo claramente
+/// sempre retorna (ex.: `if` com then E else ambos retornando).
+///
+/// Não tenta análise de fluxo completa; apenas evita falsos positivos nas
+/// situações mais comuns de funções de disciplina.
+fn body_always_returns(stmts: &[Stmt]) -> bool {
+    match stmts.last() {
+        Some(Stmt::Return(Some(_), _)) => true,
+        Some(Stmt::If(_, then, Some(else_), _)) => {
+            stmt_always_returns(then) && stmt_always_returns(else_)
+        }
+        Some(Stmt::Block(inner, _)) => body_always_returns(inner),
+        _ => false,
+    }
+}
+
+/// Verifica se um único statement sempre retorna (auxiliar de `body_always_returns`).
+fn stmt_always_returns(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Return(Some(_), _) => true,
+        Stmt::Block(stmts, _) => body_always_returns(stmts),
+        Stmt::If(_, then, Some(else_), _) => {
+            stmt_always_returns(then) && stmt_always_returns(else_)
+        }
+        _ => false,
+    }
 }
 
 fn infer_literal_type(lit: &Literal) -> QualifierType {

--- a/src/common/errors/types.rs
+++ b/src/common/errors/types.rs
@@ -206,6 +206,14 @@ pub enum SemanticErrorKind {
     NotIndexable {
         found: String,
     },
+    /// Expressão do `switch` não é de tipo inteiro.
+    InvalidSwitchType {
+        found: String,
+    },
+    /// `break` usado fora de loop ou `switch`.
+    BreakOutsideLoop,
+    /// `continue` usado fora de loop.
+    ContinueOutsideLoop,
 }
 
 #[derive(Debug)]
@@ -309,6 +317,32 @@ impl ToReport for SemanticError {
                     self.span.clone(),
                     format!("'{}' não é indexável (esperado array ou ponteiro)", found),
                 ),
+            SemanticErrorKind::InvalidSwitchType { found } => {
+                Report::new("invalid switch expression type")
+                    .with_span(self.span.clone())
+                    .with_label(
+                        self.span.clone(),
+                        format!(
+                            "expressão do switch deve ser inteira, encontrado '{}'",
+                            found
+                        ),
+                    )
+                    .with_help("use int, char, short, long ou enum como discriminante do switch")
+            }
+            SemanticErrorKind::BreakOutsideLoop => Report::new("break outside loop or switch")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    "'break' só pode ser usado dentro de loop ou switch".to_string(),
+                )
+                .with_help("mova o 'break' para dentro de um for, while, do-while ou switch"),
+            SemanticErrorKind::ContinueOutsideLoop => Report::new("continue outside loop")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    "'continue' só pode ser usado dentro de loop".to_string(),
+                )
+                .with_help("mova o 'continue' para dentro de um for, while ou do-while"),
         }
     }
 }
@@ -326,6 +360,8 @@ pub enum SemanticWarningKind {
     UnusedVariable(String),
     /// Variável lida antes de receber qualquer inicializador ou atribuição.
     MayBeUninitialized(String),
+    /// Função não-void sem `return` detectado no caminho de saída principal.
+    MissingReturn(String),
 }
 
 #[derive(Debug)]
@@ -355,6 +391,16 @@ impl ToReport for SemanticWarning {
                     )
                     .with_help("inicialize a variavel antes de usa-la")
             }
+            SemanticWarningKind::MissingReturn(fn_name) => Report::new("missing return")
+                .with_span(self.span.clone())
+                .with_label(
+                    self.span.clone(),
+                    format!(
+                        "função '{}' não-void pode encerrar sem retornar valor",
+                        fn_name
+                    ),
+                )
+                .with_help("adicione um 'return <expr>;' ao final da função"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,11 +273,19 @@ fn run(source: SourceFile, args: &CliArgs) -> Result<(), Box<dyn ToReport>> {
     }
 
     // ── Stage 3: Semantic ────────────────────────────────────────────────────
-    let sem_errors = analyse_with_builtins(&program, scanner.builtins);
-    let sem_count = sem_errors.len();
+    let sem_diagnostics = analyse_with_builtins(&program, scanner.builtins);
+    let sem_warnings: Vec<_> = sem_diagnostics.iter().filter(|d| d.is_warning()).collect();
+    if !sem_warnings.is_empty() {
+        eprintln!("\n=== Semantic Warnings ({}) ===", sem_warnings.len());
+        for w in &sem_warnings {
+            print_warning_report(&w.to_report());
+        }
+    }
+
+    let sem_count = sem_diagnostics.iter().filter(|d| d.is_error()).count();
     if sem_count > 0 {
         eprintln!("\n=== Semantic Errors ({sem_count}) ===");
-        for e in &sem_errors {
+        for e in sem_diagnostics.iter().filter(|d| d.is_error()) {
             print_report(&e.to_report());
         }
         return Err(Box::new(DiagnosticError { count: sem_count }));
@@ -435,7 +443,15 @@ fn dump_ast(program: &crusty::common::ast::ast::Program) {
 // ── Error reporting ───────────────────────────────────────────────────────────
 
 fn print_report(report: &Report) {
-    eprintln!("  error: {}", report.message);
+    print_report_with_prefix(report, "error");
+}
+
+fn print_warning_report(report: &Report) {
+    print_report_with_prefix(report, "warning");
+}
+
+fn print_report_with_prefix(report: &Report, prefix: &str) {
+    eprintln!("  {prefix}: {}", report.message);
     if let Some(span) = &report.span {
         eprintln!("    --> {}:{}", span.line, span.column_start);
     }

--- a/src/tests/analyzer_test.rs
+++ b/src/tests/analyzer_test.rs
@@ -147,6 +147,7 @@ mod test {
 
     #[test]
     fn test_return_type_mismatch_error() {
+        // int f() { return "texto"; }  → incompatível (char* não é conversível para int)
         let mut analyser = SemanticAnalyser::new();
         let span = dummy_span();
 
@@ -156,7 +157,7 @@ mod test {
             is_unsigned: false,
         };
 
-        let expr_errada = Expr::Literal(Literal::Double(2.5), span.clone());
+        let expr_errada = Expr::Literal(Literal::String("texto".to_string()), span.clone());
         let stmt_return = Stmt::Return(Some(expr_errada), span.clone());
 
         let funcao_ast = Decl::Function(
@@ -174,7 +175,7 @@ mod test {
         assert_eq!(
             analyser.diagnostics.len(),
             1,
-            "Deveria ter detectado incopatibilidade: Int x Double."
+            "Deveria ter detectado incompatibilidade: int x char* (return de string em função int)."
         );
     }
 

--- a/src/tests/semantic_test.rs
+++ b/src/tests/semantic_test.rs
@@ -46,7 +46,7 @@ mod tests {
     fn program(stmts: Vec<Stmt>) -> Program {
         Program {
             decls: vec![Decl::Function(
-                qty(Type::Int),
+                qty(Type::Void),
                 "main".into(),
                 vec![],
                 stmts,
@@ -524,11 +524,13 @@ mod tests {
 
     #[test]
     fn unused_variable_emits_warning() {
-        // int x = 5; return 0;   -> x declarada mas nunca lida
-        let prog = program(vec![
-            Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(5)), span()),
-            Stmt::Return(Some(int_lit(0)), span()),
-        ]);
+        // int x = 5;   -> x declarada mas nunca lida
+        let prog = program(vec![Stmt::VarDecl(
+            qty(Type::Int),
+            "x".into(),
+            Some(int_lit(5)),
+            span(),
+        )]);
         let diags = analyse(&prog);
         assert!(errors(&diags).is_empty(), "não deve haver erros");
         assert!(
@@ -545,7 +547,7 @@ mod tests {
     fn used_variable_emits_no_warning() {
         let prog = program(vec![
             Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(5)), span()),
-            Stmt::Return(Some(ident("x")), span()),
+            Stmt::ExprStmt(ident("x"), span()),
         ]);
         let diags = analyse(&prog);
         assert!(
@@ -579,10 +581,10 @@ mod tests {
 
     #[test]
     fn uninitialized_use_emits_warning() {
-        // int x; return x;  -> x lida sem inicialização
+        // int x; _ = x;  -> x lida sem inicialização
         let prog = program(vec![
             Stmt::VarDecl(qty(Type::Int), "x".into(), None, span()),
-            Stmt::Return(Some(ident("x")), span()),
+            Stmt::ExprStmt(ident("x"), span()),
         ]);
         let diags = analyse(&prog);
         assert!(errors(&diags).is_empty(), "não deve haver erros");
@@ -598,10 +600,10 @@ mod tests {
 
     #[test]
     fn initialized_then_used_emits_no_warning() {
-        // int x = 0; return x;  -> x inicializada, nenhum warning
+        // int x = 0; _ = x;  -> x inicializada, nenhum warning
         let prog = program(vec![
             Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(0)), span()),
-            Stmt::Return(Some(ident("x")), span()),
+            Stmt::ExprStmt(ident("x"), span()),
         ]);
         assert!(analyse(&prog).is_empty());
     }
@@ -616,7 +618,7 @@ mod tests {
                     qty(Type::Int),
                     "f".into(),
                     vec![(qty(Type::Int), "a".into())],
-                    vec![],
+                    vec![Stmt::Return(Some(ident("a")), span())],
                     span(),
                 ),
                 Decl::Function(
@@ -998,7 +1000,7 @@ mod tests {
     #[test]
     fn prototype_valid_forward_call_is_ok() {
         // int soma(int a, int b);
-        // int main() { return soma(1, 2); }
+        // void main() { soma(1, 2); }
         // int soma(int a, int b) { return a + b; }
         let prog = Program {
             decls: vec![
@@ -1009,15 +1011,15 @@ mod tests {
                     span(),
                 ),
                 Decl::Function(
-                    qty(Type::Int),
+                    qty(Type::Void),
                     "main".into(),
                     vec![],
-                    vec![Stmt::Return(
-                        Some(Expr::Call(
+                    vec![Stmt::ExprStmt(
+                        Expr::Call(
                             Box::new(ident("soma")),
                             vec![int_lit(1), int_lit(2)],
                             span(),
-                        )),
+                        ),
                         span(),
                     )],
                     span(),
@@ -1026,7 +1028,7 @@ mod tests {
                     qty(Type::Int),
                     "soma".into(),
                     vec![(qty(Type::Int), "a".into()), (qty(Type::Int), "b".into())],
-                    vec![],
+                    vec![Stmt::Return(Some(ident("a")), span())],
                     span(),
                 ),
             ],
@@ -1176,6 +1178,315 @@ mod tests {
                     if matches!(w.kind, SemanticWarningKind::MayBeUninitialized(_))
             )),
             "atribuição antes do uso inicializa a variável"
+        );
+    }
+
+    // ── return: verificação de tipo com coerção numérica ──────────────────────
+
+    #[test]
+    fn return_int_from_long_fn_is_ok() {
+        // long f() { return 1; }  → coerção int→long permitida
+        let prog = Program {
+            decls: vec![Decl::Function(
+                qty(Type::Long),
+                "f".into(),
+                vec![],
+                vec![Stmt::Return(Some(int_lit(1)), span())],
+                span(),
+            )],
+        };
+        assert!(
+            errors(&analyse(&prog)).is_empty(),
+            "return int em função long deve ser válido (coerção numérica)"
+        );
+    }
+
+    #[test]
+    fn return_string_from_int_fn_emits_error() {
+        // int f() { return "oi"; }  → incompatível
+        let prog = Program {
+            decls: vec![Decl::Function(
+                qty(Type::Int),
+                "f".into(),
+                vec![],
+                vec![Stmt::Return(
+                    Some(Expr::Literal(Literal::String("oi".into()), span())),
+                    span(),
+                )],
+                span(),
+            )],
+        };
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::TypeMismatch { .. })
+            )),
+            "return char* em função int deve emitir TypeMismatch"
+        );
+    }
+
+    #[test]
+    fn return_missing_in_non_void_fn_emits_warning() {
+        // int f() { }  → aviso de missing return
+        let prog = Program {
+            decls: vec![Decl::Function(
+                qty(Type::Int),
+                "f".into(),
+                vec![],
+                vec![],
+                span(),
+            )],
+        };
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).is_empty(),
+            "missing return não deve ser um erro"
+        );
+        assert!(
+            diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(&w.kind, SemanticWarningKind::MissingReturn(n) if n == "f")
+            )),
+            "função int sem return deve emitir MissingReturn"
+        );
+    }
+
+    #[test]
+    fn return_void_fn_no_return_is_ok() {
+        // void f() { }  → sem aviso de missing return
+        let prog = Program {
+            decls: vec![Decl::Function(
+                qty(Type::Void),
+                "f".into(),
+                vec![],
+                vec![],
+                span(),
+            )],
+        };
+        let diags = analyse(&prog);
+        assert!(
+            !diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(&w.kind, SemanticWarningKind::MissingReturn(_))
+            )),
+            "função void sem return não deve emitir MissingReturn"
+        );
+    }
+
+    #[test]
+    fn return_with_explicit_return_suppresses_missing_return_warning() {
+        // int f() { return 0; }  → sem aviso
+        let prog = Program {
+            decls: vec![Decl::Function(
+                qty(Type::Int),
+                "f".into(),
+                vec![],
+                vec![Stmt::Return(Some(int_lit(0)), span())],
+                span(),
+            )],
+        };
+        let diags = analyse(&prog);
+        assert!(
+            !diags.iter().any(|d| matches!(
+                d,
+                Diagnostic::Warning(crate::common::errors::types::CompilerWarning::Semantic(w))
+                    if matches!(&w.kind, SemanticWarningKind::MissingReturn(_))
+            )),
+            "função com return explícito não deve emitir MissingReturn"
+        );
+    }
+
+    // ── switch: tipo do discriminante ─────────────────────────────────────────
+
+    #[test]
+    fn switch_int_expr_is_ok() {
+        let prog = program(vec![Stmt::Switch(int_lit(1), vec![], span())]);
+        assert!(
+            errors(&analyse(&prog)).is_empty(),
+            "switch(int) deve ser válido"
+        );
+    }
+
+    #[test]
+    fn switch_float_expr_emits_invalid_switch_type() {
+        let prog = program(vec![Stmt::Switch(
+            Expr::Literal(Literal::Double(1.5), span()),
+            vec![],
+            span(),
+        )]);
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::InvalidSwitchType { .. })
+            )),
+            "switch(double) deve emitir InvalidSwitchType"
+        );
+    }
+
+    #[test]
+    fn switch_case_exprs_are_analysed() {
+        // switch(x) { case y: break; }  onde y é indefinido → UndefinedVariable
+        let prog = program(vec![
+            Stmt::VarDecl(qty(Type::Int), "x".into(), Some(int_lit(0)), span()),
+            Stmt::Switch(
+                ident("x"),
+                vec![crate::common::ast::stmt::SwitchCase {
+                    label: crate::common::ast::stmt::SwitchLabel::Case(ident("y_undefined")),
+                    stmts: vec![Stmt::Break(span())],
+                    span: span(),
+                }],
+                span(),
+            ),
+        ]);
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::UndefinedVariable(n) if n == "y_undefined")
+            )),
+            "expressão de case indefinida deve emitir UndefinedVariable"
+        );
+    }
+
+    // ── break / continue fora de contexto ────────────────────────────────────
+
+    #[test]
+    fn break_inside_while_is_ok() {
+        let prog = program(vec![Stmt::While(
+            int_lit(1),
+            Box::new(Stmt::Break(span())),
+            span(),
+        )]);
+        assert!(
+            errors(&analyse(&prog)).is_empty(),
+            "break dentro de while deve ser válido"
+        );
+    }
+
+    #[test]
+    fn break_inside_switch_is_ok() {
+        let prog = program(vec![Stmt::Switch(
+            int_lit(0),
+            vec![crate::common::ast::stmt::SwitchCase {
+                label: crate::common::ast::stmt::SwitchLabel::Default,
+                stmts: vec![Stmt::Break(span())],
+                span: span(),
+            }],
+            span(),
+        )]);
+        assert!(
+            errors(&analyse(&prog)).is_empty(),
+            "break dentro de switch deve ser válido"
+        );
+    }
+
+    #[test]
+    fn break_outside_loop_emits_error() {
+        let prog = program(vec![Stmt::Break(span())]);
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::BreakOutsideLoop)
+            )),
+            "break fora de loop/switch deve emitir BreakOutsideLoop"
+        );
+    }
+
+    #[test]
+    fn continue_inside_for_is_ok() {
+        let prog = program(vec![Stmt::For(
+            None,
+            Some(int_lit(1)),
+            None,
+            Box::new(Stmt::Continue(span())),
+            span(),
+        )]);
+        assert!(
+            errors(&analyse(&prog)).is_empty(),
+            "continue dentro de for deve ser válido"
+        );
+    }
+
+    #[test]
+    fn continue_outside_loop_emits_error() {
+        let prog = program(vec![Stmt::Continue(span())]);
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::ContinueOutsideLoop)
+            )),
+            "continue fora de loop deve emitir ContinueOutsideLoop"
+        );
+    }
+
+    #[test]
+    fn continue_inside_switch_emits_error() {
+        // `continue` dentro de switch sem loop externo é inválido em C
+        let prog = program(vec![Stmt::Switch(
+            int_lit(0),
+            vec![crate::common::ast::stmt::SwitchCase {
+                label: crate::common::ast::stmt::SwitchLabel::Default,
+                stmts: vec![Stmt::Continue(span())],
+                span: span(),
+            }],
+            span(),
+        )]);
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::ContinueOutsideLoop)
+            )),
+            "continue dentro de switch (sem loop externo) deve emitir ContinueOutsideLoop"
+        );
+    }
+
+    // ── VarDecl local: verificação de tipo do inicializador ───────────────────
+
+    #[test]
+    fn local_var_init_type_mismatch_emits_error() {
+        // int x = "hello";  → TypeMismatch
+        let prog = program(vec![Stmt::VarDecl(
+            qty(Type::Int),
+            "x".into(),
+            Some(Expr::Literal(Literal::String("hello".into()), span())),
+            span(),
+        )]);
+        let diags = analyse(&prog);
+        assert!(
+            errors(&diags).iter().any(|e| matches!(
+                e,
+                CompilerError::Semantic(se)
+                    if matches!(&se.kind, SemanticErrorKind::TypeMismatch { .. })
+            )),
+            "int x = string deve emitir TypeMismatch"
+        );
+    }
+
+    #[test]
+    fn local_var_init_numeric_coercion_is_ok() {
+        // int x = 1.5;  → coerção double→int, válido em C
+        let prog = program(vec![Stmt::VarDecl(
+            qty(Type::Int),
+            "x".into(),
+            Some(Expr::Literal(Literal::Double(1.5), span())),
+            span(),
+        )]);
+        assert!(
+            errors(&analyse(&prog)).is_empty(),
+            "int x = 1.5 deve ser válido (coerção numérica implícita)"
         );
     }
 }


### PR DESCRIPTION
## Descrição
Este PR resolve a issue **#160** e completa a validação semântica mínima do subconjunto da linguagem C suportado pelo projeto, com o objetivo de barrar programas inválidos comuns e fornecer feedbacks mais consistentes. 
## Mudanças Principais
- **Comando `return`:**
  - Alterada a verificação para usar a função `types_compatible_for_assign` em vez de igualdade estrita (`!=`), permitindo assim conversões válidas e reportando incompatibilidades de maneira apropriada.
- **Estruturas de Controle (`switch`, `break`, `continue`):**
  - Implementado o controle de contexto de profundidade (`loop_depth` e `switch_depth`) no `SemanticAnalyser`.
  - Adicionada a validação do tipo discriminante do `switch` (precisa ser do tipo inteiro ou emitirá `InvalidSwitchType`).
  - O uso de `break` fora de um bloco `switch` ou de repetição agora lança um erro `BreakOutsideLoop`.
  - O uso de `continue` isolado dentro de um `switch` ou fora de repetições emite um erro `ContinueOutsideLoop`.
- **Declaração de Variáveis (VarDecl):**
  - Adicionada a verificação semântica para expressões de inicialização em declarações locais de variáveis (reporta `TypeMismatch` ao tentar inicializar com tipo incompatível).
- **Heurística de `MissingReturn`:**
  - Implementada uma heurística `body_always_returns` que reporta um *warning* de `MissingReturn` para funções não-void onde não é detectado um retorno explícito no final do fluxo.
- **Chamadas de Função (Aridade e Tipos):**
  - Validada propriamente a compatibilidade de tipo e a quantidade de argumentos contra o protótipo da função (ArityMismatch e TypeMismatch).
- **Operações com Ponteiros (`AddrOf` e `Deref`):**
  - Adicionado suporte na análise de tipo de expressões unárias `&` e `*` para evitar falsos positivos de tipos ao lidar com ponteiros/arrays.
## Outras Alterações
- Refatoração dos testes legados em `semantic_test.rs` para suportar o rigor da nova validação (ex: declarando helpers com retorno tipo `void` onde aplicável).
- Criação de dezenas de novos testes semânticos cobrindo todos os cenários implementados.
- Atualização do arquivo `docs/semantic.md` com a tabela atualizada de novos erros e warnings suportados.
- Resolução de conflitos recentes de merge puxados da branch `origin/developer`.
- Ajuste de formatação com `cargo fmt`.

---

Closes #160