### PR TITLE
feat(examples): programa-demo para a apresentação final

### DIFF
--- a/src/examples/demo_presentation.c
+++ b/src/examples/demo_presentation.c
@@ -1,0 +1,39 @@
+/*
+ * Programa-demo para a apresentação final (issue #163).
+ *
+ * Mostra, em poucas linhas, os recursos centrais já estáveis do
+ * subconjunto de C suportado pelo compilador:
+ *   - variaveis e expressoes aritmeticas
+ *   - funcoes com chamada recursiva (factorial)
+ *   - controle de fluxo: if/else e while
+ *
+ * Saida esperada: exit code 80
+ *   factorial(4)          = 24
+ *   sum_even_squares(6)   = 2*2 + 4*4 + 6*6 = 56
+ *   24 + 56               = 80
+ */
+
+int factorial(int n) {
+    if (n <= 1) {
+        return 1;
+    }
+    return n * factorial(n - 1);
+}
+
+int sum_even_squares(int n) {
+    int total = 0;
+    int i = 1;
+    while (i <= n) {
+        if (i % 2 == 0) {
+            total = total + i * i;
+        }
+        i = i + 1;
+    }
+    return total;
+}
+
+int main(void) {
+    int fact4 = factorial(4);
+    int squares = sum_even_squares(6);
+    return fact4 + squares;
+}

--- a/tests/exe_smoke_test.rs
+++ b/tests/exe_smoke_test.rs
@@ -141,3 +141,20 @@ fn smoke_function_call_runs() {
     #[cfg(unix)]
     assert_eq!(status.code(), Some(42));
 }
+
+/// Garante que o programa-demo da apresentação final (issue #163), em
+/// `src/examples/demo_presentation.c`, continua compilando e produzindo o
+/// exit code documentado no cabeçalho do arquivo.
+#[test]
+fn smoke_presentation_demo_runs() {
+    require_gcc!();
+
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/examples/demo_presentation.c");
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("falha ao ler '{}': {e}", path.display()));
+
+    let status = compile_and_run("presentation_demo", &source);
+
+    #[cfg(unix)]
+    assert_eq!(status.code(), Some(80));
+}


### PR DESCRIPTION
## Resumo
- Adiciona `src/examples/demo_presentation.c`: um programa curto (factorial recursivo + soma de quadrados de pares via `while`/`if`) que demonstra variáveis/expressões, funções e controle de fluxo — tudo dentro do subconjunto de C que o backend já suporta de forma estável.
- `struct`, ponteiros e `switch` não foram usados no demo porque o lowering ainda não suporta atribuição via ponteiro/struct nem `switch` (ver também a nota equivalente no PR #170).
- Saída esperada documentada no cabeçalho do arquivo: exit code `80` (`factorial(4) = 24` + `sum_even_squares(6) = 56`).
- Adiciona `smoke_presentation_demo_runs` em `tests/exe_smoke_test.rs`, que compila e executa o exemplo de ponta a ponta via `gcc` e confere o exit code, garantindo que o demo continue funcionando conforme o pipeline evolui.

Closes #163

## Test plan
- [x] `cargo test --all` passa
- [x] `cargo clippy --all -- -D warnings` sem avisos
- [x] `cargo fmt --check` sem diffs
- [x] Caso de uso para a apresentação: `cargo run -- src/examples/demo_presentation.c -o demo && ./demo; echo $?` deve imprimir `80`